### PR TITLE
feat(infra): implement cloudwatch.yaml — alarms + operational dashboard

### DIFF
--- a/sast-platform/infrastructure/cloudwatch.yaml
+++ b/sast-platform/infrastructure/cloudwatch.yaml
@@ -1,0 +1,410 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  CloudWatch Alarms and Dashboard for the SAST Platform.
+  Covers Lambda A, Lambda B, SQS queues, and DynamoDB.
+  Deploy AFTER: sast-sqs, sast-lambda-a, sast-lambda-b, sast-dynamodb.
+
+Parameters:
+  ProjectName:
+    Type: String
+    Default: sast-platform
+  Environment:
+    Type: String
+    Default: dev
+    AllowedValues: [dev, staging, prod]
+  SQSStackName:
+    Type: String
+    Default: sast-sqs
+  LambdaAStackName:
+    Type: String
+    Default: sast-lambda-a
+  LambdaBStackName:
+    Type: String
+    Default: sast-lambda-b
+  DynamoDBStackName:
+    Type: String
+    Default: sast-dynamodb
+  LambdaAFunctionName:
+    Type: String
+    Default: sast-lambda-a
+    Description: Must match the function name in lambda_a.yaml
+  AlertEmail:
+    Type: String
+    Default: ""
+    Description: Optional — email for alarm notifications
+
+Conditions:
+  HasAlertEmail: !Not [!Equals [!Ref AlertEmail, ""]]
+
+Resources:
+
+  # ── SNS Alert Topic ──────────────────────────────────────────────────────────
+  AlertTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: !Sub "${ProjectName}-${Environment}-alerts"
+      Subscription: !If
+        - HasAlertEmail
+        - - Protocol: email
+            Endpoint: !Ref AlertEmail
+        - []
+
+  # ── Lambda A Alarms ──────────────────────────────────────────────────────────
+  LambdaAErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${ProjectName}-${Environment}-lambda-a-errors"
+      AlarmDescription: "Lambda A: >= 3 errors in 5 min — API layer failing"
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref LambdaAFunctionName
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 3
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      AlarmActions: [!Ref AlertTopic]
+      OKActions: [!Ref AlertTopic]
+
+  LambdaADurationAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${ProjectName}-${Environment}-lambda-a-duration"
+      AlarmDescription: "Lambda A: avg duration >= 25s (approaching 30s timeout)"
+      Namespace: AWS/Lambda
+      MetricName: Duration
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref LambdaAFunctionName
+      Statistic: Average
+      Period: 300
+      EvaluationPeriods: 2
+      Threshold: 25000
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      AlarmActions: [!Ref AlertTopic]
+
+  LambdaAThrottleAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${ProjectName}-${Environment}-lambda-a-throttles"
+      AlarmDescription: "Lambda A: throttle events detected"
+      Namespace: AWS/Lambda
+      MetricName: Throttles
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref LambdaAFunctionName
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      AlarmActions: [!Ref AlertTopic]
+
+  # ── SQS Alarms ───────────────────────────────────────────────────────────────
+  # lambda_b.yaml already has inline error/duration/throttle alarms for Lambda B.
+  # These alarms cover the queue layer, which lambda_b.yaml does not watch.
+
+  ScanQueueDepthAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${ProjectName}-${Environment}-sqs-queue-depth"
+      AlarmDescription: "SQS queue >= 50 messages — Lambda B may be backed up"
+      Namespace: AWS/SQS
+      MetricName: ApproximateNumberOfMessagesVisible
+      Dimensions:
+        - Name: QueueName
+          Value: !ImportValue
+            Fn::Sub: "${SQSStackName}-ScanQueueName"
+      Statistic: Maximum
+      Period: 300
+      EvaluationPeriods: 2
+      Threshold: 50
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      AlarmActions: [!Ref AlertTopic]
+      OKActions: [!Ref AlertTopic]
+
+  ScanDLQAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${ProjectName}-${Environment}-sqs-dlq-messages"
+      AlarmDescription: "SQS DLQ has messages — scans failing after 3 retries (see issue #23)"
+      Namespace: AWS/SQS
+      MetricName: ApproximateNumberOfMessagesVisible
+      Dimensions:
+        - Name: QueueName
+          Value: !Select
+            - 4
+            - !Split
+              - "/"
+              - !ImportValue
+                  Fn::Sub: "${SQSStackName}-DLQUrl"
+      Statistic: Sum
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      AlarmActions: [!Ref AlertTopic]
+      OKActions: [!Ref AlertTopic]
+
+  # ── DynamoDB Alarms ──────────────────────────────────────────────────────────
+  DynamoDBThrottleAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${ProjectName}-${Environment}-dynamodb-throttles"
+      AlarmDescription: "DynamoDB: >= 5 throttled requests in 5 min"
+      Namespace: AWS/DynamoDB
+      MetricName: ThrottledRequests
+      Dimensions:
+        - Name: TableName
+          Value: !ImportValue
+            Fn::Sub: "${DynamoDBStackName}-ScanResultsTableName"
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 5
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      AlarmActions: [!Ref AlertTopic]
+
+  DynamoDBSystemErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${ProjectName}-${Environment}-dynamodb-system-errors"
+      AlarmDescription: "DynamoDB system errors detected"
+      Namespace: AWS/DynamoDB
+      MetricName: SystemErrors
+      Dimensions:
+        - Name: TableName
+          Value: !ImportValue
+            Fn::Sub: "${DynamoDBStackName}-ScanResultsTableName"
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      AlarmActions: [!Ref AlertTopic]
+
+  # ── CloudWatch Dashboard ─────────────────────────────────────────────────────
+  # Layout mirrors the "Operational Overview" structure from the OpenAI dashboard
+  # design guide: workspace title → section headers → metric rows (KPIs + status
+  # table per service). Dense, readable, minimal chrome.
+  SASTDashboard:
+    Type: AWS::CloudWatch::Dashboard
+    Properties:
+      DashboardName: !Sub "${ProjectName}-${Environment}-overview"
+      DashboardBody: !Sub
+        - |
+          {
+            "widgets": [
+              {
+                "type": "text", "x": 0, "y": 0, "width": 24, "height": 1,
+                "properties": {
+                  "markdown": "# SAST Platform — Operational Overview  `${Environment}`\nTrack health, throughput, and active work across the scan pipeline."
+                }
+              },
+              {
+                "type": "alarm", "x": 0, "y": 1, "width": 24, "height": 2,
+                "properties": {
+                  "title": "Active Alarms",
+                  "alarms": [
+                    "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${ProjectName}-${Environment}-lambda-a-errors",
+                    "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${ProjectName}-${Environment}-lambda-a-duration",
+                    "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${ProjectName}-${Environment}-lambda-a-throttles",
+                    "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${ProjectName}-${Environment}-sqs-queue-depth",
+                    "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${ProjectName}-${Environment}-sqs-dlq-messages",
+                    "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${ProjectName}-${Environment}-dynamodb-throttles",
+                    "arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:${ProjectName}-${Environment}-dynamodb-system-errors"
+                  ]
+                }
+              },
+              {
+                "type": "text", "x": 0, "y": 3, "width": 24, "height": 1,
+                "properties": { "markdown": "## Lambda A — API Layer  *(POST /scan · GET /status)*" }
+              },
+              {
+                "type": "metric", "x": 0, "y": 4, "width": 6, "height": 6,
+                "properties": {
+                  "title": "Invocations",
+                  "metrics": [["AWS/Lambda","Invocations","FunctionName","${LambdaAFunctionName}",{"stat":"Sum","label":"Total"}]],
+                  "period": 300, "view": "timeSeries", "stacked": false
+                }
+              },
+              {
+                "type": "metric", "x": 6, "y": 4, "width": 6, "height": 6,
+                "properties": {
+                  "title": "Errors",
+                  "metrics": [["AWS/Lambda","Errors","FunctionName","${LambdaAFunctionName}",{"stat":"Sum","color":"#d13212"}]],
+                  "period": 300, "view": "timeSeries",
+                  "annotations": {"horizontal": [{"value": 3, "label": "Alarm threshold", "color": "#d13212"}]}
+                }
+              },
+              {
+                "type": "metric", "x": 12, "y": 4, "width": 6, "height": 6,
+                "properties": {
+                  "title": "Duration (ms)",
+                  "metrics": [
+                    ["AWS/Lambda","Duration","FunctionName","${LambdaAFunctionName}",{"stat":"Average","label":"avg"}],
+                    ["AWS/Lambda","Duration","FunctionName","${LambdaAFunctionName}",{"stat":"p99","label":"p99"}]
+                  ],
+                  "period": 300, "view": "timeSeries",
+                  "annotations": {"horizontal": [{"value": 25000, "label": "≥25s alarm", "color": "#ff9900"}]}
+                }
+              },
+              {
+                "type": "metric", "x": 18, "y": 4, "width": 6, "height": 6,
+                "properties": {
+                  "title": "Throttles",
+                  "metrics": [["AWS/Lambda","Throttles","FunctionName","${LambdaAFunctionName}",{"stat":"Sum","color":"#8c4fff"}]],
+                  "period": 300, "view": "timeSeries"
+                }
+              },
+              {
+                "type": "text", "x": 0, "y": 10, "width": 24, "height": 1,
+                "properties": { "markdown": "## Lambda B — Scan Engine  *(Bandit · Semgrep · ECS fallback)*" }
+              },
+              {
+                "type": "metric", "x": 0, "y": 11, "width": 6, "height": 6,
+                "properties": {
+                  "title": "Invocations",
+                  "metrics": [["AWS/Lambda","Invocations","FunctionName","${LambdaBFunctionName}",{"stat":"Sum","label":"Total"}]],
+                  "period": 300, "view": "timeSeries"
+                }
+              },
+              {
+                "type": "metric", "x": 6, "y": 11, "width": 6, "height": 6,
+                "properties": {
+                  "title": "Errors",
+                  "metrics": [["AWS/Lambda","Errors","FunctionName","${LambdaBFunctionName}",{"stat":"Sum","color":"#d13212"}]],
+                  "period": 300, "view": "timeSeries",
+                  "annotations": {"horizontal": [{"value": 5, "label": "Alarm threshold", "color": "#d13212"}]}
+                }
+              },
+              {
+                "type": "metric", "x": 12, "y": 11, "width": 6, "height": 6,
+                "properties": {
+                  "title": "Duration (ms)",
+                  "metrics": [
+                    ["AWS/Lambda","Duration","FunctionName","${LambdaBFunctionName}",{"stat":"Average","label":"avg"}],
+                    ["AWS/Lambda","Duration","FunctionName","${LambdaBFunctionName}",{"stat":"p99","label":"p99"}]
+                  ],
+                  "period": 300, "view": "timeSeries",
+                  "annotations": {"horizontal": [{"value": 800000, "label": "≥13 min alarm", "color": "#ff9900"}]}
+                }
+              },
+              {
+                "type": "metric", "x": 18, "y": 11, "width": 6, "height": 6,
+                "properties": {
+                  "title": "Concurrent Executions",
+                  "metrics": [["AWS/Lambda","ConcurrentExecutions","FunctionName","${LambdaBFunctionName}",{"stat":"Maximum","color":"#1f77b4"}]],
+                  "period": 300, "view": "timeSeries",
+                  "annotations": {"horizontal": [{"value": 50, "label": "Reserved concurrency limit", "color": "#ff9900"}]}
+                }
+              },
+              {
+                "type": "text", "x": 0, "y": 17, "width": 24, "height": 1,
+                "properties": { "markdown": "## SQS — Scan Pipeline  *(Queue depth · Throughput · Dead letters)*" }
+              },
+              {
+                "type": "metric", "x": 0, "y": 18, "width": 8, "height": 6,
+                "properties": {
+                  "title": "Queue Depth (backlog)",
+                  "metrics": [
+                    ["AWS/SQS","ApproximateNumberOfMessagesVisible","QueueName","${ScanQueueName}",{"stat":"Maximum","label":"Visible","color":"#1f77b4"}],
+                    ["AWS/SQS","ApproximateNumberOfMessagesNotVisible","QueueName","${ScanQueueName}",{"stat":"Maximum","label":"In-flight","color":"#aec7e8"}]
+                  ],
+                  "period": 300, "view": "timeSeries",
+                  "annotations": {"horizontal": [{"value": 50, "label": "Alarm (>=50)", "color": "#d13212"}]}
+                }
+              },
+              {
+                "type": "metric", "x": 8, "y": 18, "width": 8, "height": 6,
+                "properties": {
+                  "title": "Throughput (Sent vs Processed)",
+                  "metrics": [
+                    ["AWS/SQS","NumberOfMessagesSent","QueueName","${ScanQueueName}",{"stat":"Sum","label":"Sent","color":"#2ca02c"}],
+                    ["AWS/SQS","NumberOfMessagesDeleted","QueueName","${ScanQueueName}",{"stat":"Sum","label":"Processed","color":"#98df8a"}]
+                  ],
+                  "period": 300, "view": "timeSeries"
+                }
+              },
+              {
+                "type": "metric", "x": 16, "y": 18, "width": 8, "height": 6,
+                "properties": {
+                  "title": "Dead Letter Queue — should be 0",
+                  "metrics": [["AWS/SQS","ApproximateNumberOfMessagesVisible","QueueName","${DLQName}",{"stat":"Sum","color":"#d13212","label":"Dead letters"}]],
+                  "period": 60, "view": "timeSeries",
+                  "annotations": {"horizontal": [{"value": 1, "label": "Alarm (any message)", "color": "#d13212"}]}
+                }
+              },
+              {
+                "type": "text", "x": 0, "y": 24, "width": 24, "height": 1,
+                "properties": { "markdown": "## DynamoDB — ScanResults Table  *(Latency · Throttles · Errors)*" }
+              },
+              {
+                "type": "metric", "x": 0, "y": 25, "width": 8, "height": 6,
+                "properties": {
+                  "title": "Request Latency (ms)",
+                  "metrics": [
+                    ["AWS/DynamoDB","SuccessfulRequestLatency","TableName","${DynamoDBTableName}","Operation","PutItem",{"stat":"Average","label":"PutItem"}],
+                    ["AWS/DynamoDB","SuccessfulRequestLatency","TableName","${DynamoDBTableName}","Operation","UpdateItem",{"stat":"Average","label":"UpdateItem"}],
+                    ["AWS/DynamoDB","SuccessfulRequestLatency","TableName","${DynamoDBTableName}","Operation","Query",{"stat":"Average","label":"Query"}]
+                  ],
+                  "period": 300, "view": "timeSeries"
+                }
+              },
+              {
+                "type": "metric", "x": 8, "y": 25, "width": 8, "height": 6,
+                "properties": {
+                  "title": "Throttled Requests",
+                  "metrics": [["AWS/DynamoDB","ThrottledRequests","TableName","${DynamoDBTableName}",{"stat":"Sum","color":"#ff9900"}]],
+                  "period": 300, "view": "timeSeries",
+                  "annotations": {"horizontal": [{"value": 5, "label": "Alarm (>=5)", "color": "#d13212"}]}
+                }
+              },
+              {
+                "type": "metric", "x": 16, "y": 25, "width": 8, "height": 6,
+                "properties": {
+                  "title": "System Errors",
+                  "metrics": [["AWS/DynamoDB","SystemErrors","TableName","${DynamoDBTableName}",{"stat":"Sum","color":"#d13212"}]],
+                  "period": 300, "view": "timeSeries"
+                }
+              }
+            ]
+          }
+        - LambdaBFunctionName: !ImportValue
+            Fn::Sub: "${ProjectName}-${Environment}-lambda-b-function-name"
+          ScanQueueName: !ImportValue
+            Fn::Sub: "${SQSStackName}-ScanQueueName"
+          DLQName: !Select
+            - 4
+            - !Split
+              - "/"
+              - !ImportValue
+                  Fn::Sub: "${SQSStackName}-DLQUrl"
+          DynamoDBTableName: !ImportValue
+            Fn::Sub: "${DynamoDBStackName}-ScanResultsTableName"
+
+Outputs:
+  AlertTopicArn:
+    Description: SNS topic ARN for alarm notifications
+    Value: !Ref AlertTopic
+    Export:
+      Name: !Sub "${ProjectName}-${Environment}-alert-topic-arn"
+
+  DashboardName:
+    Description: CloudWatch dashboard name
+    Value: !Sub "${ProjectName}-${Environment}-overview"
+    Export:
+      Name: !Sub "${ProjectName}-${Environment}-dashboard-name"
+
+  DashboardUrl:
+    Description: Direct link to the CloudWatch dashboard in the AWS console
+    Value: !Sub "https://${AWS::Region}.console.aws.amazon.com/cloudwatch/home?region=${AWS::Region}#dashboards:name=${ProjectName}-${Environment}-overview"

--- a/sast-platform/infrastructure/cloudwatch.yaml
+++ b/sast-platform/infrastructure/cloudwatch.yaml
@@ -14,16 +14,10 @@ Parameters:
     AllowedValues: [dev, staging, prod]
   SQSStackName:
     Type: String
-    Default: sast-sqs
-  LambdaAStackName:
-    Type: String
-    Default: sast-lambda-a
-  LambdaBStackName:
-    Type: String
-    Default: sast-lambda-b
+    Default: sast-platform-sqs
   DynamoDBStackName:
     Type: String
-    Default: sast-dynamodb
+    Default: sast-platform-dynamodb
   LambdaAFunctionName:
     Type: String
     Default: sast-lambda-a
@@ -144,7 +138,7 @@ Resources:
               - "/"
               - !ImportValue
                   Fn::Sub: "${SQSStackName}-DLQUrl"
-      Statistic: Sum
+      Statistic: Maximum
       Period: 60
       EvaluationPeriods: 1
       Threshold: 1

--- a/sast-platform/scripts/01_setup_infra.sh
+++ b/sast-platform/scripts/01_setup_infra.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# 01_setup_infra.sh — Deploy all CloudFormation stacks in dependency order.
+#
+# Usage:
+#   ./01_setup_infra.sh [OPTIONS]
+#
+# Required:
+#   --code-bucket   S3 bucket where lambda_a.zip / lambda_b.zip are uploaded
+#
+# Optional:
+#   --project       Project name prefix        (default: sast-platform)
+#   --env           Environment                (default: dev)
+#   --region        AWS region                 (default: us-east-1)
+#   --vpc-id        VPC ID for ECS tasks       (skip ECS stack if omitted)
+#   --subnets       Comma-separated subnet IDs (required when --vpc-id is set)
+#   --scanner-image ECR image URI for ECS scanner
+#                   (default: placeholder — update after running 04_build_ecs_image.sh)
+#
+# Environment variable equivalents (override flags):
+#   CODE_BUCKET, PROJECT_NAME, ENVIRONMENT, AWS_REGION, VPC_ID, SUBNET_IDS, SCANNER_IMAGE
+#
+# Deployment order:
+#   1. s3          (no upstream deps)
+#   2. dynamodb    (no upstream deps)
+#   3. sqs         (no upstream deps)
+#   4. lambda_a    (needs s3, dynamodb, sqs outputs)
+#   5. lambda_b    (needs s3, dynamodb, sqs outputs)
+#   6. ecs         (needs s3, dynamodb — OPTIONAL, skipped if --vpc-id not set)
+#   7. cloudwatch  (needs all above stacks)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INFRA_DIR="$(dirname "$SCRIPT_DIR")/infrastructure"
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+PROJECT_NAME="${PROJECT_NAME:-sast-platform}"
+ENVIRONMENT="${ENVIRONMENT:-dev}"
+AWS_REGION="${AWS_REGION:-us-east-1}"
+CODE_BUCKET="${CODE_BUCKET:-}"
+VPC_ID="${VPC_ID:-}"
+SUBNET_IDS="${SUBNET_IDS:-}"
+SCANNER_IMAGE="${SCANNER_IMAGE:-}"
+
+# ── Argument parsing ───────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --project)       PROJECT_NAME="$2";   shift 2 ;;
+    --env)           ENVIRONMENT="$2";    shift 2 ;;
+    --region)        AWS_REGION="$2";     shift 2 ;;
+    --code-bucket)   CODE_BUCKET="$2";    shift 2 ;;
+    --vpc-id)        VPC_ID="$2";         shift 2 ;;
+    --subnets)       SUBNET_IDS="$2";     shift 2 ;;
+    --scanner-image) SCANNER_IMAGE="$2";  shift 2 ;;
+    *) echo "Unknown argument: $1"; exit 1 ;;
+  esac
+done
+
+# ── Validation ─────────────────────────────────────────────────────────────────
+if [[ -z "$CODE_BUCKET" ]]; then
+  echo "ERROR: --code-bucket is required (S3 bucket containing lambda_a.zip and lambda_b.zip)"
+  exit 1
+fi
+
+if [[ -n "$VPC_ID" && -z "$SUBNET_IDS" ]]; then
+  echo "ERROR: --subnets is required when --vpc-id is set"
+  exit 1
+fi
+
+# ── Stack name convention (must match cloudwatch.yaml parameter defaults) ──────
+STACK_S3="${PROJECT_NAME}-s3"
+STACK_DYNAMODB="${PROJECT_NAME}-dynamodb"          # cloudwatch default: sast-platform-dynamodb (adjusted below)
+STACK_SQS="${PROJECT_NAME}-sqs"                    # cloudwatch default: sast-sqs — see note
+STACK_LAMBDA_A="${PROJECT_NAME}-lambda-a"
+STACK_LAMBDA_B="${PROJECT_NAME}-lambda-b"
+STACK_ECS="${PROJECT_NAME}-ecs"
+STACK_CLOUDWATCH="${PROJECT_NAME}-cloudwatch"
+
+# Shared resource names (consistent across stacks)
+TABLE_NAME="ScanResults"
+REPORT_BUCKET="${PROJECT_NAME}-reports-${ENVIRONMENT}"
+FRONTEND_BUCKET="${PROJECT_NAME}-frontend-${ENVIRONMENT}"
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+log()  { echo "[$(date '+%H:%M:%S')] $*"; }
+ok()   { echo "[$(date '+%H:%M:%S')] ✓ $*"; }
+fail() { echo "[$(date '+%H:%M:%S')] ✗ $*" >&2; exit 1; }
+
+deploy_stack() {
+  local stack_name="$1"
+  local template_file="$2"
+  shift 2
+  local params=("$@")
+
+  log "Deploying stack: $stack_name"
+  log "  Template: $template_file"
+
+  local param_args=()
+  for p in "${params[@]}"; do
+    param_args+=(--parameter-overrides "$p")
+  done
+
+  if aws cloudformation deploy \
+    --stack-name "$stack_name" \
+    --template-file "$template_file" \
+    --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
+    --region "$AWS_REGION" \
+    "${param_args[@]}" \
+    --no-fail-on-empty-changeset; then
+    ok "Stack deployed: $stack_name"
+  else
+    fail "Stack deployment failed: $stack_name"
+  fi
+}
+
+get_output() {
+  local stack_name="$1"
+  local output_key="$2"
+  aws cloudformation describe-stacks \
+    --stack-name "$stack_name" \
+    --region "$AWS_REGION" \
+    --query "Stacks[0].Outputs[?OutputKey=='$output_key'].OutputValue" \
+    --output text
+}
+
+# ── Print config ───────────────────────────────────────────────────────────────
+echo ""
+echo "╔══════════════════════════════════════════════════════╗"
+echo "║       SAST Platform — Infrastructure Setup           ║"
+echo "╠══════════════════════════════════════════════════════╣"
+printf  "║  Project:    %-38s ║\n" "$PROJECT_NAME"
+printf  "║  Environment:%-38s ║\n" "$ENVIRONMENT"
+printf  "║  Region:     %-38s ║\n" "$AWS_REGION"
+printf  "║  Code Bucket:%-38s ║\n" "$CODE_BUCKET"
+if [[ -n "$VPC_ID" ]]; then
+printf  "║  VPC:        %-38s ║\n" "$VPC_ID"
+printf  "║  Subnets:    %-38s ║\n" "${SUBNET_IDS:0:38}"
+else
+printf  "║  ECS stack:  %-38s ║\n" "SKIPPED (no --vpc-id)"
+fi
+echo "╚══════════════════════════════════════════════════════╝"
+echo ""
+
+# ── 1. S3 ──────────────────────────────────────────────────────────────────────
+deploy_stack "$STACK_S3" "$INFRA_DIR/s3.yaml" \
+  "ReportBucketName=$REPORT_BUCKET" \
+  "FrontendBucketName=$FRONTEND_BUCKET"
+
+# ── 2. DynamoDB ────────────────────────────────────────────────────────────────
+deploy_stack "$STACK_DYNAMODB" "$INFRA_DIR/dynamodb.yaml" \
+  "TableName=$TABLE_NAME"
+
+# ── 3. SQS ────────────────────────────────────────────────────────────────────
+deploy_stack "$STACK_SQS" "$INFRA_DIR/sqs.yaml" \
+  "QueueName=${PROJECT_NAME}-scan-queue" \
+  "DLQName=${PROJECT_NAME}-scan-dlq"
+
+# Query SQS outputs needed by Lambda stacks
+SQS_QUEUE_ARN="$(get_output "$STACK_SQS" ScanQueueArn)"
+[[ -z "$SQS_QUEUE_ARN" ]] && fail "Could not read ScanQueueArn from $STACK_SQS"
+log "SQS Queue ARN: $SQS_QUEUE_ARN"
+
+# ── 4. Lambda A ────────────────────────────────────────────────────────────────
+deploy_stack "$STACK_LAMBDA_A" "$INFRA_DIR/lambda_a.yaml" \
+  "CodeBucket=$CODE_BUCKET" \
+  "CodeKey=lambda_a.zip" \
+  "DynamoDBTableName=$TABLE_NAME" \
+  "S3ReportBucket=$REPORT_BUCKET" \
+  "SQSStackName=$STACK_SQS"
+
+LAMBDA_A_URL="$(get_output "$STACK_LAMBDA_A" LambdaAFunctionUrl 2>/dev/null || true)"
+
+# ── 5. Lambda B ────────────────────────────────────────────────────────────────
+deploy_stack "$STACK_LAMBDA_B" "$INFRA_DIR/lambda_b.yaml" \
+  "ProjectName=$PROJECT_NAME" \
+  "Environment=$ENVIRONMENT" \
+  "SQSQueueArn=$SQS_QUEUE_ARN" \
+  "DynamoDBTableName=$TABLE_NAME" \
+  "S3BucketName=$REPORT_BUCKET" \
+  "ECSClusterName=" \
+  "ECSTaskDefinitionArn="
+
+# ── 6. ECS (optional) ─────────────────────────────────────────────────────────
+ECS_CLUSTER_NAME=""
+ECS_TASK_DEF_ARN=""
+
+if [[ -n "$VPC_ID" ]]; then
+  DEFAULT_IMAGE="${PROJECT_NAME}.dkr.ecr.${AWS_REGION}.amazonaws.com/sast-scanner:latest"
+  SCANNER_IMAGE="${SCANNER_IMAGE:-$DEFAULT_IMAGE}"
+
+  deploy_stack "$STACK_ECS" "$INFRA_DIR/ecs.yaml" \
+    "ProjectName=$PROJECT_NAME" \
+    "Environment=$ENVIRONMENT" \
+    "VpcId=$VPC_ID" \
+    "SubnetIds=$SUBNET_IDS" \
+    "ScannerImageUri=$SCANNER_IMAGE" \
+    "DynamoDBTableName=$TABLE_NAME" \
+    "S3BucketName=$REPORT_BUCKET"
+
+  ECS_CLUSTER_NAME="$(get_output "$STACK_ECS" ECSClusterName)"
+  ECS_TASK_DEF_ARN="$(get_output "$STACK_ECS" TaskDefinitionArn)"
+
+  # Update Lambda B with ECS references now that ECS stack exists
+  log "Updating Lambda B with ECS cluster reference..."
+  deploy_stack "$STACK_LAMBDA_B" "$INFRA_DIR/lambda_b.yaml" \
+    "ProjectName=$PROJECT_NAME" \
+    "Environment=$ENVIRONMENT" \
+    "SQSQueueArn=$SQS_QUEUE_ARN" \
+    "DynamoDBTableName=$TABLE_NAME" \
+    "S3BucketName=$REPORT_BUCKET" \
+    "ECSClusterName=$ECS_CLUSTER_NAME" \
+    "ECSTaskDefinitionArn=$ECS_TASK_DEF_ARN"
+else
+  log "Skipping ECS stack (--vpc-id not provided). ECS fallback will be unavailable."
+fi
+
+# ── 7. CloudWatch ─────────────────────────────────────────────────────────────
+deploy_stack "$STACK_CLOUDWATCH" "$INFRA_DIR/cloudwatch.yaml" \
+  "ProjectName=$PROJECT_NAME" \
+  "Environment=$ENVIRONMENT" \
+  "SQSStackName=$STACK_SQS" \
+  "LambdaAStackName=$STACK_LAMBDA_A" \
+  "LambdaBStackName=$STACK_LAMBDA_B" \
+  "DynamoDBStackName=$STACK_DYNAMODB"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "╔══════════════════════════════════════════════════════╗"
+echo "║               Deployment Complete                    ║"
+echo "╠══════════════════════════════════════════════════════╣"
+
+# Re-query Lambda A URL (may have been set after deploy)
+LAMBDA_A_URL="$(get_output "$STACK_LAMBDA_A" LambdaAFunctionUrl 2>/dev/null || true)"
+SQS_URL="$(get_output "$STACK_SQS" ScanQueueUrl)"
+DLQ_URL="$(get_output "$STACK_SQS" DeadLetterQueueUrl)"
+
+printf "║  Lambda A URL:   %-34s ║\n" "${LAMBDA_A_URL:-<check console>}"
+printf "║  Report Bucket:  %-34s ║\n" "$REPORT_BUCKET"
+printf "║  Frontend Bucket:%-34s ║\n" "$FRONTEND_BUCKET"
+printf "║  DynamoDB Table: %-34s ║\n" "$TABLE_NAME"
+printf "║  SQS Queue URL:  %-34s ║\n" "${SQS_URL:-<check console>}"
+printf "║  DLQ URL:        %-34s ║\n" "${DLQ_URL:-<check console>}"
+if [[ -n "$ECS_CLUSTER_NAME" ]]; then
+printf "║  ECS Cluster:    %-34s ║\n" "$ECS_CLUSTER_NAME"
+fi
+echo "╠══════════════════════════════════════════════════════╣"
+echo "║  Next step: run 02_deploy_lambda_a.sh                ║"
+echo "╚══════════════════════════════════════════════════════╝"
+echo ""

--- a/sast-platform/scripts/01_setup_infra.sh
+++ b/sast-platform/scripts/01_setup_infra.sh
@@ -219,9 +219,8 @@ deploy_stack "$STACK_CLOUDWATCH" "$INFRA_DIR/cloudwatch.yaml" \
   "ProjectName=$PROJECT_NAME" \
   "Environment=$ENVIRONMENT" \
   "SQSStackName=$STACK_SQS" \
-  "LambdaAStackName=$STACK_LAMBDA_A" \
-  "LambdaBStackName=$STACK_LAMBDA_B" \
-  "DynamoDBStackName=$STACK_DYNAMODB"
+  "DynamoDBStackName=$STACK_DYNAMODB" \
+  "LambdaAFunctionName=sast-lambda-a"
 
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
## Summary

Closes #1

Implements `infrastructure/cloudwatch.yaml` with full CloudWatch Alarms and a consolidated Operational Overview Dashboard.

## What's included

### Alarms (7 new, all wired to SNS AlertTopic)

| Alarm | Threshold | Why |
|-------|-----------|-----|
| Lambda A errors | >= 3 in 5 min | API layer failing |
| Lambda A duration | avg >= 25s | Approaching 30s timeout |
| Lambda A throttles | >= 1 | Concurrency pressure |
| SQS queue depth | >= 50 messages | Lambda B backed up |
| SQS DLQ | any message | Scan failed 3 retries (issue #23) |
| DynamoDB throttles | >= 5 in 5 min | Write/read pressure |
| DynamoDB system errors | >= 1 | Infrastructure fault |

> **Note:** `lambda_b.yaml` already defines inline Lambda B error/duration/throttle alarms. This stack intentionally does not duplicate them — it covers Lambda A and queue-level visibility which lambda_b.yaml does not provide.

### Dashboard

4-section operational overview layout:
- **Active Alarms** status row at top (all 7 alarms at a glance)
- **Lambda A** — Invocations, Errors, Duration (avg+p99), Throttles
- **Lambda B** — Invocations, Errors, Duration (avg+p99), Concurrent Executions
- **SQS** — Queue depth (visible + in-flight), Throughput (sent vs processed), DLQ depth
- **DynamoDB** — Request latency (PutItem/UpdateItem/Query), Throttles, System errors

All threshold annotations are shown on graphs as reference lines.

### SNS

`AlertEmail` parameter is optional — leave blank to skip email subscription. Topic ARN is exported as `${ProjectName}-${Environment}-alert-topic-arn` for other stacks to reference.

## Deploy order

This stack must be deployed **last**, after:
```
sast-dynamodb → sast-s3 → sast-sqs → sast-lambda-a → sast-lambda-b → sast-ecs → sast-cloudwatch
```

## Review checklist

- [ ] Alarm thresholds look reasonable for course project scale
- [ ] Stack parameter defaults match your deployed stack names
- [ ] `LambdaAFunctionName` default (`sast-lambda-a`) matches your actual function name

🤖 Generated with [Claude Code](https://claude.com/claude-code)