### PR TITLE
feat(frontend): implement index.html, app.js, style.css — closes #6

### DIFF
--- a/sast-platform/frontend/css/style.css
+++ b/sast-platform/frontend/css/style.css
@@ -1,0 +1,291 @@
+/* ============================================================
+   style.css — Student Assignment Security Checker
+   Mengshan Li | CS6620 Group 9
+   ============================================================ */
+
+/* ------------------------------------------------------------
+   Reset & base
+   ------------------------------------------------------------ */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: #f4f6f9;
+  color: #1a1a2e;
+  line-height: 1.5;
+}
+
+/* ------------------------------------------------------------
+   Layout
+   ------------------------------------------------------------ */
+.page-wrapper {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+header {
+  margin-bottom: 1.5rem;
+  text-align: center;
+}
+
+header h1 {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: #0f3460;
+}
+
+main {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.card {
+  background: #ffffff;
+  border: 1px solid #dde1ea;
+  border-radius: 8px;
+  padding: 1.5rem;
+  box-shadow: 0 1px 4px rgba(0,0,0,.06);
+}
+
+.card h2 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  color: #0f3460;
+  border-bottom: 1px solid #eef0f4;
+  padding-bottom: .5rem;
+}
+
+.hidden { display: none !important; }
+
+/* ------------------------------------------------------------
+   Form
+   ------------------------------------------------------------ */
+.form-group {
+  margin-bottom: 1rem;
+}
+
+.form-group label {
+  display: block;
+  font-size: .875rem;
+  font-weight: 600;
+  margin-bottom: .35rem;
+  color: #444;
+}
+
+.form-group input[type="text"],
+.form-group select,
+.form-group textarea {
+  width: 100%;
+  padding: .55rem .75rem;
+  border: 1px solid #c8cdd8;
+  border-radius: 6px;
+  font-size: .95rem;
+  font-family: inherit;
+  transition: border-color .15s;
+  background: #fafbfc;
+}
+
+.form-group input[type="text"]:focus,
+.form-group select:focus,
+.form-group textarea:focus {
+  outline: none;
+  border-color: #4a90d9;
+  background: #fff;
+}
+
+.form-group textarea {
+  resize: vertical;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: .875rem;
+  min-height: 200px;
+}
+
+/* ------------------------------------------------------------
+   Buttons
+   ------------------------------------------------------------ */
+.btn-primary {
+  display: inline-block;
+  padding: .6rem 1.4rem;
+  background: #0f3460;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  font-size: .95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background .15s;
+}
+
+.btn-primary:hover:not(:disabled)  { background: #16213e; }
+.btn-primary:disabled { background: #8fa8c8; cursor: not-allowed; }
+
+.btn-link {
+  background: none;
+  border: none;
+  color: #4a90d9;
+  cursor: pointer;
+  font-size: .9rem;
+  text-decoration: underline;
+  padding: 0;
+}
+
+.dismiss-btn {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 1rem;
+  margin-left: auto;
+  padding: 0 .25rem;
+  opacity: .7;
+}
+.dismiss-btn:hover { opacity: 1; }
+
+/* ------------------------------------------------------------
+   Error banner
+   ------------------------------------------------------------ */
+.error-banner {
+  display: flex;
+  align-items: center;
+  gap: .75rem;
+  background: #fde8e8;
+  border: 1px solid #f5a0a0;
+  border-radius: 6px;
+  padding: .75rem 1rem;
+  color: #b91c1c;
+  font-size: .9rem;
+}
+
+.error-banner #error-message { flex: 1; }
+
+/* ------------------------------------------------------------
+   Status section
+   ------------------------------------------------------------ */
+.status-row {
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+  margin-bottom: .5rem;
+  font-size: .95rem;
+}
+
+.status-row .label {
+  font-weight: 600;
+  min-width: 72px;
+  color: #555;
+}
+
+.expiry-warning {
+  margin-top: .75rem;
+  font-size: .875rem;
+  color: #b45309;
+  background: #fef3c7;
+  border: 1px solid #fcd34d;
+  border-radius: 5px;
+  padding: .5rem .75rem;
+}
+
+/* ------------------------------------------------------------
+   Loading spinner
+   ------------------------------------------------------------ */
+.spinner {
+  display: inline-block;
+  width: 18px;
+  height: 18px;
+  border: 2.5px solid #c8cdd8;
+  border-top-color: #4a90d9;
+  border-radius: 50%;
+  animation: spin .7s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* ------------------------------------------------------------
+   Severity badges
+   ------------------------------------------------------------ */
+.severity-badge {
+  display: inline-block;
+  padding: .2rem .55rem;
+  border-radius: 4px;
+  font-size: .78rem;
+  font-weight: 700;
+  letter-spacing: .03em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.severity-high   { background: #fee2e2; color: #991b1b; border: 1px solid #fca5a5; }
+.severity-medium { background: #ffedd5; color: #9a3412; border: 1px solid #fdba74; }
+.severity-low    { background: #fef9c3; color: #854d0e; border: 1px solid #fde047; }
+
+/* ------------------------------------------------------------
+   Results section
+   ------------------------------------------------------------ */
+.result-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .5rem 2rem;
+  margin-bottom: 1rem;
+  font-size: .9rem;
+  color: #444;
+}
+
+.result-summary {
+  display: flex;
+  gap: .5rem;
+  margin-bottom: 1rem;
+}
+
+.result-findings { overflow-x: auto; }
+
+.result-findings table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: .875rem;
+}
+
+.result-findings thead th {
+  background: #f0f2f5;
+  color: #333;
+  font-weight: 600;
+  text-align: left;
+  padding: .55rem .75rem;
+  border-bottom: 2px solid #dde1ea;
+  white-space: nowrap;
+}
+
+.result-findings tbody tr { border-bottom: 1px solid #eef0f4; }
+.result-findings tbody tr:nth-child(even) { background: #f9fafb; }
+.result-findings tbody tr:hover { background: #eef4ff; }
+
+.result-findings tbody td {
+  padding: .5rem .75rem;
+  vertical-align: top;
+}
+
+.result-findings pre {
+  margin: 0;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: .8rem;
+  white-space: pre-wrap;
+  word-break: break-all;
+  background: #f4f6f9;
+  padding: .3rem .5rem;
+  border-radius: 4px;
+  max-width: 320px;
+}
+
+/* ------------------------------------------------------------
+   Responsive
+   ------------------------------------------------------------ */
+@media (max-width: 600px) {
+  header h1 { font-size: 1.35rem; }
+  .card { padding: 1rem; }
+
+  .result-findings table { font-size: .8rem; }
+  .result-findings pre   { max-width: 160px; }
+}

--- a/sast-platform/frontend/index.html
+++ b/sast-platform/frontend/index.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Student Assignment Security Checker</title>
+  <link rel="stylesheet" href="css/style.css" />
+</head>
+<body>
+  <div class="page-wrapper">
+    <header>
+      <h1>Student Assignment Security Checker</h1>
+    </header>
+
+    <main>
+      <!-- Error banner -->
+      <div id="error-banner" class="error-banner hidden" role="alert">
+        <span id="error-message"></span>
+        <button class="dismiss-btn" onclick="dismissError()">✕</button>
+      </div>
+
+      <!-- Submission form -->
+      <section class="card" id="submit-section">
+        <h2>Submit Code for Scanning</h2>
+
+        <div class="form-group">
+          <label for="api-key">API Key (X-Student-Key)</label>
+          <input
+            type="text"
+            id="api-key"
+            placeholder="Enter your student API key..."
+            autocomplete="off"
+          />
+        </div>
+
+        <div class="form-group">
+          <label for="language">Language</label>
+          <select id="language">
+            <option value="">— Select language —</option>
+            <option value="python">Python</option>
+            <option value="java">Java</option>
+            <option value="javascript">JavaScript</option>
+            <option value="typescript">TypeScript</option>
+            <option value="go">Go</option>
+            <option value="ruby">Ruby</option>
+            <option value="c">C</option>
+            <option value="cpp">C++</option>
+          </select>
+        </div>
+
+        <div class="form-group">
+          <label for="code">Code</label>
+          <textarea
+            id="code"
+            rows="12"
+            placeholder="Paste your code here..."
+          ></textarea>
+        </div>
+
+        <button id="submit-btn" class="btn-primary" onclick="handleSubmit()">
+          Scan Code
+        </button>
+      </section>
+
+      <!-- Status area (hidden until submission) -->
+      <section class="card hidden" id="status-section">
+        <h2>Scan Status</h2>
+        <div class="status-row">
+          <span class="label">Scan ID:</span>
+          <code id="status-scan-id">—</code>
+        </div>
+        <div class="status-row">
+          <span class="label">Status:</span>
+          <span id="status-text">Pending...</span>
+          <span id="spinner" class="spinner" aria-label="Loading"></span>
+        </div>
+        <div id="expiry-warning" class="expiry-warning hidden">
+          ⚠️ Download link will expire soon.
+          <button class="btn-link" onclick="refreshReportLink()">Refresh link</button>
+        </div>
+      </section>
+
+      <!-- Results area — rendered by results.js -->
+      <section class="card hidden" id="results-section">
+        <h2>Scan Results</h2>
+        <div id="results"></div>
+      </section>
+    </main>
+  </div>
+
+  <script src="js/results.js"></script>
+  <script src="js/app.js"></script>
+</body>
+</html>

--- a/sast-platform/frontend/js/app.js
+++ b/sast-platform/frontend/js/app.js
@@ -1,0 +1,243 @@
+/**
+ * app.js — Frontend submission and polling logic
+ * Mengshan Li | CS6620 Group 9
+ *
+ * API_BASE_URL is replaced at deploy time by 04_upload_frontend.sh
+ * using: sed -i "s|__LAMBDA_URL__|$LAMBDA_URL|g" app.js
+ */
+
+const API_BASE_URL = "__LAMBDA_URL__";
+
+const POLL_INITIAL_MS   = 2000;
+const POLL_BACKOFF      = 1.5;
+const POLL_MAX_MS       = 30000;
+const POLL_TIMEOUT_MS   = 5 * 60 * 1000; // 5 minutes
+const EXPIRY_WARN_SECS  = 300;            // warn when < 5 min left on presigned URL
+
+const LS_API_KEY = "sasc_api_key";
+
+let _currentScanId   = null;
+let _pollTimer       = null;
+let _pollDeadline    = null;
+let _currentInterval = POLL_INITIAL_MS;
+let _reportUrl       = null;
+
+// ---------------------------------------------------------------------------
+// Initialise
+// ---------------------------------------------------------------------------
+
+document.addEventListener("DOMContentLoaded", () => {
+  const stored = localStorage.getItem(LS_API_KEY);
+  if (stored) {
+    document.getElementById("api-key").value = stored;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Submit handler
+// ---------------------------------------------------------------------------
+
+async function handleSubmit() {
+  const apiKey   = document.getElementById("api-key").value.trim();
+  const language = document.getElementById("language").value;
+  const code     = document.getElementById("code").value.trim();
+
+  dismissError();
+
+  if (!apiKey)   { showError("Please enter your API key."); return; }
+  if (!language) { showError("Please select a language."); return; }
+  if (!code)     { showError("Please paste some code to scan."); return; }
+
+  setSubmitLoading(true);
+
+  let data;
+  try {
+    const res = await fetch(`${API_BASE_URL}/scan`, {
+      method:  "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-student-key": apiKey,
+      },
+      body: JSON.stringify({ code, language }),
+    });
+
+    data = await res.json().catch(() => ({}));
+
+    if (res.status === 202) {
+      localStorage.setItem(LS_API_KEY, apiKey);
+      startPolling(data.scan_id, apiKey);
+      return;
+    }
+
+    if (res.status === 400) { showError(data.error || "Invalid request."); }
+    else if (res.status === 401) { handleUnauthorized(); }
+    else if (res.status === 429) { showError("Too many requests — please wait a moment and try again."); }
+    else { showError("Server error. Please try again."); }
+
+  } catch (_) {
+    showError("Could not reach server. Check your connection.");
+  }
+
+  setSubmitLoading(false);
+}
+
+// ---------------------------------------------------------------------------
+// Polling
+// ---------------------------------------------------------------------------
+
+function startPolling(scanId, apiKey) {
+  _currentScanId   = scanId;
+  _currentInterval = POLL_INITIAL_MS;
+  _pollDeadline    = Date.now() + POLL_TIMEOUT_MS;
+
+  showStatusSection(scanId);
+  setStatus("Scanning...", true);
+
+  _pollTimer = setTimeout(() => poll(scanId, apiKey), _currentInterval);
+}
+
+async function poll(scanId, apiKey) {
+  if (Date.now() > _pollDeadline) {
+    setStatus("Scan is taking longer than expected.", false);
+    showError(`Scan is taking longer than expected. Check back later with Scan ID: ${scanId}`);
+    setSubmitLoading(false);
+    return;
+  }
+
+  let data;
+  try {
+    const res = await fetch(`${API_BASE_URL}/status?scan_id=${encodeURIComponent(scanId)}`, {
+      headers: { "x-student-key": apiKey },
+    });
+
+    data = await res.json().catch(() => ({}));
+
+    if (res.status === 401) { handleUnauthorized(); return; }
+
+  } catch (_) {
+    showError("Could not reach server. Check your connection.");
+    setSubmitLoading(false);
+    return;
+  }
+
+  if (data.status === "DONE") {
+    await handleDone(data, apiKey);
+    return;
+  }
+
+  if (data.status === "FAILED") {
+    setStatus("Failed", false);
+    showError(`Scan failed. The code could not be processed. (Scan ID: ${scanId})`);
+    setSubmitLoading(false);
+    return;
+  }
+
+  // Still PENDING — back off and re-poll
+  _currentInterval = Math.min(_currentInterval * POLL_BACKOFF, POLL_MAX_MS);
+  _pollTimer = setTimeout(() => poll(scanId, apiKey), _currentInterval);
+}
+
+async function handleDone(statusData, apiKey) {
+  setStatus("Done", false);
+  _reportUrl = statusData.report_url;
+
+  if (!_reportUrl) {
+    showError("Scan complete but no report URL was returned.");
+    setSubmitLoading(false);
+    return;
+  }
+
+  // Warn if presigned URL is near expiry
+  if (statusData.report_url_expires_at) {
+    const secsLeft = statusData.report_url_expires_at - Math.floor(Date.now() / 1000);
+    if (secsLeft < EXPIRY_WARN_SECS) {
+      document.getElementById("expiry-warning").classList.remove("hidden");
+    }
+  }
+
+  try {
+    const reportRes = await fetch(_reportUrl);
+    if (reportRes.status === 403) {
+      showError('Download link expired. <button class="btn-link" onclick="refreshReportLink()">Click to refresh.</button>');
+      setSubmitLoading(false);
+      return;
+    }
+    const report = await reportRes.json();
+    showResultsSection();
+    window.renderScanResults(report, "results");
+  } catch (_) {
+    showError("Could not fetch scan report. Check your connection.");
+  }
+
+  setSubmitLoading(false);
+}
+
+async function refreshReportLink() {
+  if (!_currentScanId) return;
+  const apiKey = localStorage.getItem(LS_API_KEY) || "";
+  dismissError();
+  document.getElementById("expiry-warning").classList.add("hidden");
+
+  try {
+    const res  = await fetch(`${API_BASE_URL}/status?scan_id=${encodeURIComponent(_currentScanId)}`, {
+      headers: { "x-student-key": apiKey },
+    });
+    const data = await res.json().catch(() => ({}));
+    if (data.report_url) {
+      _reportUrl = data.report_url;
+      const reportRes = await fetch(_reportUrl);
+      const report    = await reportRes.json();
+      showResultsSection();
+      window.renderScanResults(report, "results");
+    }
+  } catch (_) {
+    showError("Could not refresh the download link. Check your connection.");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Auth
+// ---------------------------------------------------------------------------
+
+function handleUnauthorized() {
+  localStorage.removeItem(LS_API_KEY);
+  document.getElementById("api-key").value = "";
+  showError("Invalid API key. Please re-enter your key and try again.");
+  setSubmitLoading(false);
+}
+
+// ---------------------------------------------------------------------------
+// UI helpers
+// ---------------------------------------------------------------------------
+
+function setSubmitLoading(loading) {
+  const btn = document.getElementById("submit-btn");
+  btn.disabled    = loading;
+  btn.textContent = loading ? "Scanning..." : "Scan Code";
+}
+
+function showStatusSection(scanId) {
+  document.getElementById("status-scan-id").textContent = scanId;
+  document.getElementById("status-section").classList.remove("hidden");
+}
+
+function showResultsSection() {
+  document.getElementById("results-section").classList.remove("hidden");
+}
+
+function setStatus(text, spinning) {
+  document.getElementById("status-text").textContent = text;
+  const spinner = document.getElementById("spinner");
+  if (spinning) { spinner.classList.remove("hidden"); }
+  else          { spinner.classList.add("hidden"); }
+}
+
+function showError(html) {
+  const banner = document.getElementById("error-banner");
+  document.getElementById("error-message").innerHTML = html;
+  banner.classList.remove("hidden");
+}
+
+function dismissError() {
+  document.getElementById("error-banner").classList.add("hidden");
+}


### PR DESCRIPTION
## Summary

- **index.html** — complete page layout: API key input (persisted in `localStorage`), code `<textarea>`, language `<select>` (Python/Java/JavaScript/TypeScript/Go/Ruby/C/C++), Submit button, status area with spinner + scan ID display, `<div id="results">` mount point for `results.js`, dismissible error banner
- **app.js** — full submission + polling flow: validates inputs, `POST /scan` with `x-student-key` header, exponential-backoff polling (start 2 s, ×1.5, cap 30 s, 5-min hard timeout), fetches report from presigned S3 URL and calls `window.renderScanResults()`, expiry warning + refresh button, HTTP error handling (400/401/429/500/network); `API_BASE_URL = "__LAMBDA_URL__"` placeholder ready for `sed` injection in `04_upload_frontend.sh`
- **style.css** — responsive layout, `.severity-high/.severity-medium/.severity-low` badge colours matching `results.js`, CSS spinner, red error banner, alternating-row findings table with monospace code snippets

## Test plan

- [ ] Open `index.html` locally (or via S3 static hosting) — page renders without console errors
- [ ] Submit without API key / without language / without code → validation error shown
- [ ] Submit with dummy key to a real Lambda URL → 202 returned, status section appears, spinner visible
- [ ] Poll reaches DONE → results table rendered by `results.js`
- [ ] Poll reaches FAILED → error banner shown with scan ID
- [ ] Poll exceeds 5 min → timeout message shown
- [ ] 401 response → API key field cleared, localStorage entry removed
- [ ] API key saved to `localStorage` on first successful submit and pre-filled on reload
- [ ] Check mobile layout (≤ 600 px viewport) — no horizontal overflow

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)