### PR TITLE
fix(s3): align report path to reports/{student_id}/{scan_id}.json — Issue #8

### DIFF
--- a/sast-platform/lambda_b/handler.py
+++ b/sast-platform/lambda_b/handler.py
@@ -155,6 +155,7 @@ def process_scan_request(scan_id: str, code: str, language: str, student_id: str
         s3_key, presigned_url = write_scan_result_to_s3(
             bucket_name=s3_bucket_name,
             scan_id=scan_id,
+            student_id=student_id,
             report_data=parsed_result
         )
         

--- a/sast-platform/lambda_b/s3_writer.py
+++ b/sast-platform/lambda_b/s3_writer.py
@@ -16,11 +16,12 @@ class S3Writer:
         self.region = region
         self.s3_client = boto3.client("s3", region_name=region)
 
-    def write_scan_report(self, scan_id, report_data):
+    def write_scan_report(self, scan_id, report_data, student_id):
         """Upload a scan report and return the S3 key."""
         try:
-            # store reports under reports/ folder
-            s3_key = f"reports/{scan_id}.json"
+            # store reports under reports/{student_id}/{scan_id}.json
+            # matches the path convention documented in infrastructure/s3.yaml
+            s3_key = f"reports/{student_id}/{scan_id}.json"
 
             # convert dict to JSON string
             json_content = json.dumps(report_data, indent=2, ensure_ascii=False)
@@ -107,10 +108,10 @@ class S3Writer:
         )
 
 
-def write_scan_result_to_s3(bucket_name, scan_id, report_data, region="us-east-1"):
+def write_scan_result_to_s3(bucket_name, scan_id, student_id, report_data, region="us-east-1"):
     """Save result to S3 and return key + URL."""
     writer = S3Writer(bucket_name, region)
-    s3_key = writer.write_scan_report(scan_id, report_data)
+    s3_key = writer.write_scan_report(scan_id, report_data, student_id)
     url = writer.generate_presigned_url(s3_key)
     return s3_key, url
 


### PR DESCRIPTION
## Summary

Fixes the S3 path mismatch between `s3_writer.py` and `s3.yaml`.

| | Before | After |
|--|--------|-------|
| `s3_writer.py` | `reports/{scan_id}.json` | `reports/{student_id}/{scan_id}.json` |
| `s3.yaml` (documented) | `reports/{student_id}/{scan_id}.json` | unchanged |

## Root cause

`s3_writer.py` was storing reports without the `student_id` prefix, while `s3.yaml` documented the canonical path as `reports/{student_id}/{scan_id}.json`. When `status.py` generated presigned URLs using the key stored in DynamoDB, it would point to a non-existent S3 object.

## Changes

**`lambda_b/s3_writer.py`**
- `write_scan_report(scan_id, report_data, student_id)` — added `student_id` parameter, path changed to `reports/{student_id}/{scan_id}.json`
- `write_scan_result_to_s3(bucket_name, scan_id, student_id, report_data)` — added `student_id` parameter, passes it through

**`lambda_b/handler.py`**
- `write_scan_result_to_s3()` call now passes `student_id` (already available from SQS message)

**`lambda_a/status.py`** — no change needed. It reads `s3_report_key` from DynamoDB, which will now be written correctly by `s3_writer.py`.

## Test plan
- [ ] `POST /scan` → scan completes → verify S3 key in DynamoDB is `reports/{student_id}/{scan_id}.json`
- [ ] `GET /status` → presigned URL points to the correct S3 object and resolves successfully

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)