### PR TITLE
fix: align Python runtime to 3.12 and pin dependency versions

### DIFF
--- a/sast-platform/lambda_a/requirements.txt
+++ b/sast-platform/lambda_a/requirements.txt
@@ -3,8 +3,8 @@
 # boto3 is pre-installed in the Lambda Python runtime — no need to bundle it.
 # List it here only for local development and unit testing.
 #
-boto3>=1.34.0
+boto3==1.34.0
 
 # Test dependencies (not bundled in Lambda deployment package)
-pytest>=8.0.0
-moto[sqs,dynamodb]>=5.0.0
+pytest==8.0.0
+moto[sqs,dynamodb]==5.0.0

--- a/sast-platform/lambda_b/Dockerfile
+++ b/sast-platform/lambda_b/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage build for security scanning tools
 # Stage 1: Build Semgrep
-FROM python:3.11-slim as semgrep-builder
+FROM python:3.12-slim as semgrep-builder
 
 # Install system dependencies for building
 RUN apt-get update && apt-get install -y \
@@ -13,13 +13,13 @@ RUN apt-get update && apt-get install -y \
 RUN pip install --no-cache-dir semgrep>=1.45.0
 
 # Stage 2: Build Bandit
-FROM python:3.11-slim as bandit-builder
+FROM python:3.12-slim as bandit-builder
 
 # Install Bandit
 RUN pip install --no-cache-dir bandit[toml]>=1.7.5
 
 # Stage 3: Final runtime image
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1
@@ -39,9 +39,9 @@ RUN apt-get update && apt-get install -y \
 
 # Copy tools from builder stages
 COPY --from=semgrep-builder /usr/local/bin/semgrep /usr/local/bin/semgrep
-COPY --from=semgrep-builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
+COPY --from=semgrep-builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
 COPY --from=bandit-builder /usr/local/bin/bandit /usr/local/bin/bandit
-COPY --from=bandit-builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
+COPY --from=bandit-builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
 
 # Install additional Python dependencies
 COPY requirements.txt /tmp/requirements.txt

--- a/sast-platform/lambda_b/requirements.txt
+++ b/sast-platform/lambda_b/requirements.txt
@@ -1,5 +1,5 @@
-bandit>=1.7.5
-semgrep>=1.45.0
-boto3>=1.28.0
-botocore>=1.31.0
-typing-extensions>=4.8.0
+bandit==1.7.5
+semgrep==1.45.0
+boto3==1.34.0
+botocore==1.34.0
+typing-extensions==4.9.0


### PR DESCRIPTION
## Summary

- Update ECS `Dockerfile` all three stages (`semgrep-builder`, `bandit-builder`, final) from `python:3.11-slim` to `python:3.12-slim` to match the Lambda A/B runtime
- Update `COPY --from` paths from `python3.11/site-packages` to `python3.12/site-packages`
- Pin `lambda_b/requirements.txt` with `==` (aligned `boto3` to `1.34.0` to match `lambda_a`)
- Pin `lambda_a/requirements.txt` with `==` for reproducible local dev and test environments

## Why

Lambda A and Lambda B both use Python 3.12, but the ECS Fargate container was built on Python 3.11. This mismatch could cause silent behaviour differences on the ECS fallback path. Unpinned `>=` versions also allowed pip to resolve different transitive dependency trees between Lambda and ECS builds.

## Test plan

- [ ] `docker build` succeeds with `python:3.12-slim`
- [ ] Bandit and Semgrep binaries work correctly under Python 3.12 inside the container
- [ ] `pip install -r lambda_a/requirements.txt` and `pip install -r lambda_b/requirements.txt` resolve cleanly with pinned versions

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)