### PR TITLE
[Jiahua] fix #14 + #29: S3-staging pattern to bypass SQS 256KB limit and delete uploaded code after scan

### DIFF
--- a/sast-platform/infrastructure/s3.yaml
+++ b/sast-platform/infrastructure/s3.yaml
@@ -28,6 +28,16 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
+      LifecycleConfiguration:
+        Rules:
+          # Automatically delete uploaded source-code objects after 24 hours.
+          # Lambda B deletes them immediately after scanning, but this rule
+          # acts as a safety net for objects orphaned by crashes or errors.
+          - Id: DeleteUploadsAfter24h
+            Status: Enabled
+            Filter:
+              Prefix: uploads/
+            ExpirationInDays: 1
 
   ReportBucketPolicy:
     Type: AWS::S3::BucketPolicy

--- a/sast-platform/lambda_a/dispatcher.py
+++ b/sast-platform/lambda_a/dispatcher.py
@@ -18,23 +18,35 @@ logger.setLevel(logging.INFO)
 
 sqs      = boto3.client("sqs")
 dynamodb = boto3.resource("dynamodb")
+s3       = boto3.client("s3")
 
 
 def create_scan_job(code: str, language: str, student_id: str,
-                    sqs_url: str, table_name: str) -> str:
+                    sqs_url: str, table_name: str, s3_bucket: str) -> str:
     """
     1. Generate a unique scan_id.
-    2. Write PENDING record to DynamoDB.
-    3. Send scan job message to SQS.
+    2. Upload code to S3 (uploads/{scan_id}.txt) to avoid SQS 256KB limit.
+    3. Write PENDING record to DynamoDB.
+    4. Send scan job message to SQS (carrying S3 key, not raw code).
 
     Returns:
         scan_id (str)
 
     Raises:
-        Exception if either AWS call fails.
+        Exception if any AWS call fails.
     """
-    scan_id   = f"scan-{uuid.uuid4().hex[:8]}"
-    timestamp = datetime.now(timezone.utc).isoformat()
+    scan_id     = f"scan-{uuid.uuid4().hex[:8]}"
+    timestamp   = datetime.now(timezone.utc).isoformat()
+    s3_code_key = f"uploads/{scan_id}.txt"
+
+    # --- Upload code to S3 (avoids SQS 256KB message size limit) ---
+    s3.put_object(
+        Bucket=s3_bucket,
+        Key=s3_code_key,
+        Body=code.encode("utf-8"),
+        ContentType="text/plain",
+    )
+    logger.info("Code uploaded to S3: key=%s bucket=%s", s3_code_key, s3_bucket)
 
     # --- Write to DynamoDB (status: PENDING) ---
     table = dynamodb.Table(table_name)
@@ -47,12 +59,12 @@ def create_scan_job(code: str, language: str, student_id: str,
     })
     logger.info("DynamoDB record created: scan_id=%s student_id=%s", scan_id, student_id)
 
-    # --- Send to SQS ---
+    # --- Send to SQS (S3 key only — no raw code to stay within 256KB limit) ---
     message = {
-        "scan_id":    scan_id,
-        "student_id": student_id,
-        "language":   language,
-        "code":       code,
+        "scan_id":     scan_id,
+        "student_id":  student_id,
+        "language":    language,
+        "s3_code_key": s3_code_key,
     }
     sqs.send_message(
         QueueUrl=sqs_url,

--- a/sast-platform/lambda_a/dispatcher.py
+++ b/sast-platform/lambda_a/dispatcher.py
@@ -66,10 +66,21 @@ def create_scan_job(code: str, language: str, student_id: str,
         "language":    language,
         "s3_code_key": s3_code_key,
     }
-    sqs.send_message(
-        QueueUrl=sqs_url,
-        MessageBody=json.dumps(message),
-    )
+    try:
+        sqs.send_message(
+            QueueUrl=sqs_url,
+            MessageBody=json.dumps(message),
+        )
+    except Exception:
+        # SQS send failed — Lambda B will never receive the message, so
+        # _delete_uploaded_code in handler.py will never run.  Clean up the
+        # S3 object here to prevent it from being orphaned.
+        logger.exception("SQS send failed, cleaning up S3 upload: key=%s", s3_code_key)
+        try:
+            s3.delete_object(Bucket=s3_bucket, Key=s3_code_key)
+        except Exception:
+            logger.exception("S3 cleanup also failed: key=%s", s3_code_key)
+        raise
     logger.info("SQS message sent: scan_id=%s queue=%s", scan_id, sqs_url)
 
     return scan_id

--- a/sast-platform/lambda_a/handler.py
+++ b/sast-platform/lambda_a/handler.py
@@ -77,6 +77,7 @@ def _handle_post_scan(event):
             student_id = clean["student_id"],
             sqs_url    = SQS_QUEUE_URL,
             table_name = DYNAMODB_TABLE,
+            s3_bucket  = S3_BUCKET,
         )
     except Exception as e:
         logger.exception("Failed to dispatch scan job")

--- a/sast-platform/lambda_b/handler.py
+++ b/sast-platform/lambda_b/handler.py
@@ -24,6 +24,7 @@ logger.setLevel(logging.INFO)
 # Initialize AWS clients
 dynamodb = boto3.resource('dynamodb')
 sqs = boto3.client('sqs')
+s3 = boto3.client('s3')
 
 
 def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
@@ -61,13 +62,16 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             try:
                 # Parse message
                 message_body = json.loads(record['body'])
-                scan_id = message_body['scan_id']
-                code = message_body['code']
-                language = message_body['language']
-                student_id = message_body['student_id']
-                
+                scan_id      = message_body['scan_id']
+                s3_code_key  = message_body['s3_code_key']
+                language     = message_body['language']
+                student_id   = message_body['student_id']
+
                 logger.info(f"Started processing scan task - scan_id: {scan_id}, language: {language}")
-                
+
+                # Fetch code from S3
+                code = _fetch_code_from_s3(s3_bucket_name, s3_code_key)
+
                 # Execute scanning
                 result = process_scan_request(
                     scan_id=scan_id,
@@ -75,7 +79,8 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                     language=language,
                     student_id=student_id,
                     table=table,
-                    s3_bucket_name=s3_bucket_name
+                    s3_bucket_name=s3_bucket_name,
+                    s3_code_key=s3_code_key,
                 )
                 
                 if result['success']:
@@ -125,31 +130,22 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
 
 
 def process_scan_request(scan_id: str, code: str, language: str, student_id: str,
-                        table: Any, s3_bucket_name: str) -> Dict[str, Any]:
+                        table: Any, s3_bucket_name: str,
+                        s3_code_key: str = None) -> Dict[str, Any]:
     """
-    Process single scan request
-    
-    Args:
-        scan_id: Scan task ID
-        code: Code to be scanned
-        language: Code language
-        student_id: Student ID
-        table: DynamoDB table object
-        s3_bucket_name: S3 bucket name
-        
-    Returns:
-        Processing result
+    Process single scan request.
+    Deletes the uploaded code from S3 after scan completes (success or failure).
     """
     try:
         # Step 1: Execute security scan
         logger.info(f"Starting scan - scan_id: {scan_id}")
         raw_scan_result = scan_code_with_timeout(code, language, scan_id, timeout=300)
-        
+
         # Step 2: Parse scan results
         logger.info(f"Parsing scan results - scan_id: {scan_id}")
         parsed_result = ResultParser.parse_scan_result(raw_scan_result)
         vuln_count = ResultParser.calculate_vuln_count(parsed_result)
-        
+
         # Step 3: Write to S3
         logger.info(f"Writing scan report to S3 - scan_id: {scan_id}")
         s3_key, presigned_url = write_scan_result_to_s3(
@@ -157,7 +153,7 @@ def process_scan_request(scan_id: str, code: str, language: str, student_id: str
             scan_id=scan_id,
             report_data=parsed_result
         )
-        
+
         # Step 4: Update DynamoDB status
         logger.info(f"Updating DynamoDB status - scan_id: {scan_id}")
         update_scan_status(
@@ -168,9 +164,12 @@ def process_scan_request(scan_id: str, code: str, language: str, student_id: str
             vuln_count=vuln_count,
             s3_report_key=s3_key
         )
-        
+
+        # Step 5: Delete uploaded source code — data privacy cleanup
+        _delete_uploaded_code(s3_bucket_name, s3_code_key)
+
         logger.info(f"Scan task completed - scan_id: {scan_id}, found {vuln_count} vulnerabilities")
-        
+
         return {
             'success': True,
             'scan_id': scan_id,
@@ -178,26 +177,44 @@ def process_scan_request(scan_id: str, code: str, language: str, student_id: str
             's3_key': s3_key,
             'presigned_url': presigned_url
         }
-        
+
     except S3WriteError as e:
-        # S3 write failed, update DynamoDB to FAILED status
         logger.error(f"S3 write failed - scan_id: {scan_id}, error: {str(e)}")
         try:
             update_scan_status(table, student_id, scan_id, 'FAILED', error_message=str(e))
         except Exception as db_error:
             logger.error(f"Failed to update failure status to DynamoDB - scan_id: {scan_id}, error: {str(db_error)}")
-        
+        _delete_uploaded_code(s3_bucket_name, s3_code_key)
         return {'success': False, 'error': f"S3 write failed: {str(e)}"}
-        
+
     except Exception as e:
-        # Other errors, also update DynamoDB to FAILED status
         logger.error(f"Scan processing failed - scan_id: {scan_id}, error: {str(e)}")
         try:
             update_scan_status(table, student_id, scan_id, 'FAILED', error_message=str(e))
         except Exception as db_error:
             logger.error(f"Failed to update failure status to DynamoDB - scan_id: {scan_id}, error: {str(db_error)}")
-        
+        _delete_uploaded_code(s3_bucket_name, s3_code_key)
         return {'success': False, 'error': str(e)}
+
+
+def _fetch_code_from_s3(bucket_name: str, s3_code_key: str) -> str:
+    """Download source code from the S3 uploads prefix."""
+    response = s3.get_object(Bucket=bucket_name, Key=s3_code_key)
+    return response['Body'].read().decode('utf-8')
+
+
+def _delete_uploaded_code(bucket_name: str, s3_code_key: str) -> None:
+    """
+    Delete uploaded source code from S3 after scanning — data privacy cleanup.
+    Non-fatal: a failure here logs a warning but does not affect the scan result.
+    """
+    if not s3_code_key:
+        return
+    try:
+        s3.delete_object(Bucket=bucket_name, Key=s3_code_key)
+        logger.info(f"Deleted uploaded code - key: {s3_code_key}")
+    except Exception as e:
+        logger.warning(f"Failed to delete uploaded code - key: {s3_code_key}, error: {str(e)}")
 
 
 def update_scan_status(table: Any, student_id: str, scan_id: str, status: str,

--- a/sast-platform/lambda_b/handler.py
+++ b/sast-platform/lambda_b/handler.py
@@ -69,13 +69,11 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
 
                 logger.info(f"Started processing scan task - scan_id: {scan_id}, language: {language}")
 
-                # Fetch code from S3
-                code = _fetch_code_from_s3(s3_bucket_name, s3_code_key)
-
-                # Execute scanning
+                # process_scan_request fetches code from S3 internally so that
+                # _delete_uploaded_code is guaranteed to run on every exit path,
+                # including S3 fetch failures.
                 result = process_scan_request(
                     scan_id=scan_id,
-                    code=code,
                     language=language,
                     student_id=student_id,
                     table=table,
@@ -129,24 +127,32 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         }
 
 
-def process_scan_request(scan_id: str, code: str, language: str, student_id: str,
+def process_scan_request(scan_id: str, language: str, student_id: str,
                         table: Any, s3_bucket_name: str,
                         s3_code_key: str = None) -> Dict[str, Any]:
     """
     Process single scan request.
-    Deletes the uploaded code from S3 after scan completes (success or failure).
+
+    Fetches source code from S3 internally so that _delete_uploaded_code is
+    guaranteed to run on every exit path — including S3 fetch failures.
+    Previously, fetching outside this function meant a fetch error left the
+    uploaded object in S3 permanently.
     """
     try:
-        # Step 1: Execute security scan
+        # Step 1: Fetch source code from S3
+        logger.info(f"Fetching code from S3 - scan_id: {scan_id}, key: {s3_code_key}")
+        code = _fetch_code_from_s3(s3_bucket_name, s3_code_key)
+
+        # Step 2: Execute security scan
         logger.info(f"Starting scan - scan_id: {scan_id}")
         raw_scan_result = scan_code_with_timeout(code, language, scan_id, timeout=300)
 
-        # Step 2: Parse scan results
+        # Step 3: Parse scan results
         logger.info(f"Parsing scan results - scan_id: {scan_id}")
         parsed_result = ResultParser.parse_scan_result(raw_scan_result)
         vuln_count = ResultParser.calculate_vuln_count(parsed_result)
 
-        # Step 3: Write to S3
+        # Step 4: Write report to S3
         logger.info(f"Writing scan report to S3 - scan_id: {scan_id}")
         s3_key, presigned_url = write_scan_result_to_s3(
             bucket_name=s3_bucket_name,
@@ -154,7 +160,7 @@ def process_scan_request(scan_id: str, code: str, language: str, student_id: str
             report_data=parsed_result
         )
 
-        # Step 4: Update DynamoDB status
+        # Step 5: Update DynamoDB status
         logger.info(f"Updating DynamoDB status - scan_id: {scan_id}")
         update_scan_status(
             table=table,
@@ -165,7 +171,7 @@ def process_scan_request(scan_id: str, code: str, language: str, student_id: str
             s3_report_key=s3_key
         )
 
-        # Step 5: Delete uploaded source code — data privacy cleanup
+        # Step 6: Delete uploaded source code — data privacy cleanup
         _delete_uploaded_code(s3_bucket_name, s3_code_key)
 
         logger.info(f"Scan task completed - scan_id: {scan_id}, found {vuln_count} vulnerabilities")


### PR DESCRIPTION
## Summary

Implements the S3-staging pattern described in issue #14, and includes the post-scan cleanup from issue #29 as part of the same flow.

## Problem

`dispatcher.py` was sending raw `code` (up to 1 MB) directly in the SQS message body. SQS has a hard 256 KB limit — any submission between ~200 KB and 1 MB was silently rejected, leaving the scan stuck at `PENDING` forever.

## Changes

### `lambda_a/dispatcher.py`
- Upload code to `uploads/{scan_id}.txt` in S3 before enqueueing
- SQS message now carries `s3_code_key` instead of raw `code`
- Added `s3_bucket` parameter to `create_scan_job()`

### `lambda_a/handler.py`
- Pass `S3_BUCKET` env var to `create_scan_job()`

### `lambda_b/handler.py`
- Read `s3_code_key` from SQS message (replaces `code`)
- `_fetch_code_from_s3()` — downloads code from S3 before scanning
- `_delete_uploaded_code()` — deletes `uploads/{scan_id}.txt` after scan (success or failure); non-fatal, failure only logs a warning
- Deletion called in all three exit paths of `process_scan_request`

## Relation to PR #42

PR #42 added `_delete_uploaded_code()` but it was a no-op because Lambda A never wrote to S3. This PR implements the full end-to-end flow, making cleanup actually work. PR #42 can be closed in favour of this one.

Closes #14
Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)