### PR TITLE
[Jiahua] fix #16: enforce ownership check on GET /status

### DIFF
--- a/sast-platform/lambda_a/handler.py
+++ b/sast-platform/lambda_a/handler.py
@@ -95,15 +95,19 @@ def _handle_post_scan(event):
 # ---------------------------------------------------------------------------
 
 def _handle_get_status(event):
-    params  = event.get("queryStringParameters") or {}
-    scan_id = params.get("scan_id", "").strip()
+    params     = event.get("queryStringParameters") or {}
+    scan_id    = params.get("scan_id",    "").strip()
+    student_id = params.get("student_id", "").strip()
 
     if not scan_id:
         return _response(400, {"error": "Query parameter 'scan_id' is required."})
+    if not student_id:
+        return _response(400, {"error": "Query parameter 'student_id' is required."})
 
     try:
         result = get_scan_status(
             scan_id    = scan_id,
+            student_id = student_id,
             table_name = DYNAMODB_TABLE,
             s3_bucket  = S3_BUCKET,
         )

--- a/sast-platform/lambda_a/status.py
+++ b/sast-platform/lambda_a/status.py
@@ -23,9 +23,14 @@ s3       = boto3.client("s3")
 PRESIGNED_URL_EXPIRY = 3600  # seconds (1 hour)
 
 
-def get_scan_status(scan_id: str, table_name: str, s3_bucket: str) -> dict:
+def get_scan_status(scan_id: str, student_id: str, table_name: str, s3_bucket: str) -> dict:
     """
-    Look up a scan record by scan_id using the GSI (scan_id-index).
+    Look up a scan record using the table primary key (student_id + scan_id).
+
+    Using the primary key instead of the GSI enforces ownership: a student
+    can only retrieve their own scan results.  If the (student_id, scan_id)
+    pair does not exist the record is treated as not found, preventing
+    cross-tenant enumeration.
 
     Returns a dict with:
       - status: PENDING | DONE | FAILED
@@ -35,23 +40,21 @@ def get_scan_status(scan_id: str, table_name: str, s3_bucket: str) -> dict:
       - (when DONE) vuln_count, completed_at, report_url (presigned S3 URL)
 
     Raises:
-        ValueError  if scan_id not found
+        ValueError  if scan_id not found or does not belong to student_id
         ClientError if AWS call fails
     """
     table = dynamodb.Table(table_name)
 
-    # Query the GSI — scan_id is not the primary key (student_id is)
-    response = table.query(
-        IndexName="scan_id-index",
-        KeyConditionExpression=Key("scan_id").eq(scan_id),
-        Limit=1,
+    # Use primary key lookup — automatically enforces ownership
+    response = table.get_item(
+        Key={"student_id": student_id, "scan_id": scan_id}
     )
 
-    items = response.get("Items", [])
-    if not items:
+    item = response.get("Item")
+    if not item:
+        # Return the same 404 whether the scan doesn't exist or belongs to
+        # another student, to avoid leaking ownership information.
         raise ValueError(f"scan_id '{scan_id}' not found.")
-
-    item = items[0]
     result = {
         "scan_id":    item["scan_id"],
         "status":     item["status"],


### PR DESCRIPTION
## Summary

`GET /status` previously accepted any `scan_id` from anyone, with no check that the requester owns that scan. This fix closes the cross-tenant data leakage.

- **`handler.py`**: require `student_id` as a query parameter. Returns `400` if missing.
- **`status.py`**: replace the GSI query (`scan_id-index`) with a primary-key `get_item` call using `(student_id, scan_id)`. Ownership is now enforced at the database level — a student can only retrieve their own scan results. A wrong `student_id` returns the same `404` as a missing `scan_id`, preventing enumeration.

Closes #16

## Test plan

- [ ] `GET /status?scan_id=X&student_id=correct_owner` → 200 with scan result
- [ ] `GET /status?scan_id=X&student_id=different_student` → 404
- [ ] `GET /status?scan_id=X` (no student_id) → 400
- [ ] `GET /status?student_id=Y` (no scan_id) → 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)