### PR TITLE
[Jiahua] fix #21: presigned URL expiry hint and frontend refresh button

### DIFF
--- a/sast-platform/frontend/js/app.js
+++ b/sast-platform/frontend/js/app.js
@@ -269,3 +269,20 @@ function showError(html) {
 function dismissError() {
   document.getElementById("error-banner").classList.add("hidden");
 }
+
+// ── Public API for results.js ─────────────────────────────────────────────────
+
+/**
+ * Fetch the current status for a scan once and return the parsed JSON.
+ * Used by the "Refresh link" button in results.js to get a fresh presigned URL
+ * without re-running the full polling loop.
+ */
+window.pollStatus = async function pollStatus(scanId) {
+  const apiKey = localStorage.getItem(LS_API_KEY) || "";
+  const res = await fetch(
+    `${API_BASE_URL}/status?scan_id=${encodeURIComponent(scanId)}`,
+    { headers: { "x-student-key": apiKey } }
+  );
+  if (!res.ok) throw new Error(`Status request failed (${res.status})`);
+  return res.json();
+};

--- a/sast-platform/frontend/js/results.js
+++ b/sast-platform/frontend/js/results.js
@@ -34,9 +34,8 @@ function normalizeSummary(summary) {
 function buildDownloadSection(report) {
 	if (!report?.report_url) return "";
 
-	const expiresAt   = report.report_url_expires_at;
-	const scanId      = report.scan_id;
-	const studentId   = report.student_id;
+	const expiresAt = report.report_url_expires_at;
+	const scanId    = report.scan_id;
 
 	let expiryHtml = "";
 	let refreshHtml = "";
@@ -52,8 +51,10 @@ function buildDownloadSection(report) {
 			expiryHtml = `<p class="url-expiry">Download link expires at: <strong>${escapeHtml(expiresLocal)}</strong></p>`;
 		}
 
-		// Show refresh button if pollStatus is available (loaded from app.js)
-		if (scanId && studentId && typeof window.pollStatus === "function") {
+		// Show refresh button if pollStatus is available (loaded from app.js).
+		// Auth is handled via X-Student-Key header inside window.pollStatus —
+		// student_id is not needed here.
+		if (scanId && typeof window.pollStatus === "function") {
 			refreshHtml = `<button id="refresh-url-btn" type="button">Refresh link</button>`;
 		}
 	}
@@ -78,12 +79,10 @@ function attachRefreshHandler(report, container) {
 	if (!btn) return;
 
 	btn.addEventListener("click", async () => {
-		btn.disabled  = true;
+		btn.disabled    = true;
 		btn.textContent = "Refreshing...";
 		try {
-			const fresh = await window.pollStatus(report.scan_id, report.student_id, {
-				maxWaitMs: 10_000,  // give up after 10 s if not DONE yet
-			});
+			const fresh = await window.pollStatus(report.scan_id);
 			renderScanResults(fresh, container);
 		} catch (err) {
 			btn.disabled    = false;

--- a/sast-platform/frontend/js/results.js
+++ b/sast-platform/frontend/js/results.js
@@ -23,25 +23,95 @@ function normalizeSummary(summary) {
 	};
 }
 
+/**
+ * Build the download link section.
+ *
+ * If report_url_expires_at is present, show when the link expires and wire up
+ * a "Refresh link" button that re-calls GET /status to get a fresh URL.
+ * This prevents students from getting a silent 403 when they return after
+ * the 1-hour presigned URL TTL.
+ */
+function buildDownloadSection(report) {
+	if (!report?.report_url) return "";
+
+	const expiresAt   = report.report_url_expires_at;
+	const scanId      = report.scan_id;
+	const studentId   = report.student_id;
+
+	let expiryHtml = "";
+	let refreshHtml = "";
+
+	if (expiresAt) {
+		const expiresDate  = new Date(expiresAt);
+		const expiresLocal = expiresDate.toLocaleString();
+		const isExpired    = Date.now() >= expiresDate.getTime();
+
+		if (isExpired) {
+			expiryHtml = `<p class="url-expired">Download link has expired. Click "Refresh link" to get a new one.</p>`;
+		} else {
+			expiryHtml = `<p class="url-expiry">Download link expires at: <strong>${escapeHtml(expiresLocal)}</strong></p>`;
+		}
+
+		// Show refresh button if pollStatus is available (loaded from app.js)
+		if (scanId && studentId && typeof window.pollStatus === "function") {
+			refreshHtml = `<button id="refresh-url-btn" type="button">Refresh link</button>`;
+		}
+	}
+
+	return `
+		<section class="result-download">
+			<a href="${escapeHtml(report.report_url)}" target="_blank" rel="noopener noreferrer" id="download-link">
+				Download full report (JSON)
+			</a>
+			${expiryHtml}
+			${refreshHtml}
+		</section>
+	`;
+}
+
+/**
+ * Attach the "Refresh link" button handler after the DOM has been updated.
+ * Calls window.pollStatus to get a fresh presigned URL, then re-renders.
+ */
+function attachRefreshHandler(report, container) {
+	const btn = container.querySelector("#refresh-url-btn");
+	if (!btn) return;
+
+	btn.addEventListener("click", async () => {
+		btn.disabled  = true;
+		btn.textContent = "Refreshing...";
+		try {
+			const fresh = await window.pollStatus(report.scan_id, report.student_id, {
+				maxWaitMs: 10_000,  // give up after 10 s if not DONE yet
+			});
+			renderScanResults(fresh, container);
+		} catch (err) {
+			btn.disabled    = false;
+			btn.textContent = "Refresh link";
+			alert("Could not refresh link: " + err.message);
+		}
+	});
+}
+
 function renderScanResults(report, target = "results") {
 	const container = typeof target === "string" ? document.getElementById(target) : target;
 	if (!container) return;
 
-	const findings = Array.isArray(report?.findings) ? report.findings : [];
-	const summary = normalizeSummary(report?.summary || {});
+	const findings  = Array.isArray(report?.findings) ? report.findings : [];
+	const summary   = normalizeSummary(report?.summary || {});
 	const vulnCount = Number(report?.vuln_count ?? findings.length);
-	const scanId = escapeHtml(report?.scan_id || "-");
-	const tool = escapeHtml(report?.tool || "-");
-	const language = escapeHtml(report?.language || "-");
+	const scanId    = escapeHtml(report?.scan_id || "-");
+	const tool      = escapeHtml(report?.tool || "-");
+	const language  = escapeHtml(report?.language || "-");
 
 	const rows = findings
 		.map((finding) => {
-			const severity = String(finding?.severity || "LOW").toUpperCase();
+			const severity   = String(finding?.severity || "LOW").toUpperCase();
 			const confidence = escapeHtml(finding?.confidence || "UNKNOWN");
-			const issue = escapeHtml(finding?.issue || "Unknown issue");
-			const line = Number(finding?.line ?? 0);
-			const snippet = escapeHtml(finding?.code_snippet || "");
-			const ruleId = escapeHtml(finding?.rule_id || "UNKNOWN");
+			const issue      = escapeHtml(finding?.issue || "Unknown issue");
+			const line       = Number(finding?.line ?? 0);
+			const snippet    = escapeHtml(finding?.code_snippet || "");
+			const ruleId     = escapeHtml(finding?.rule_id || "UNKNOWN");
 
 			return `
 				<tr>
@@ -70,6 +140,8 @@ function renderScanResults(report, target = "results") {
 			<span class="${severityBadgeClass("LOW")}">LOW ${summary.LOW}</span>
 		</section>
 
+		${buildDownloadSection(report)}
+
 		<section class="result-findings">
 			<table>
 				<thead>
@@ -88,6 +160,8 @@ function renderScanResults(report, target = "results") {
 			</table>
 		</section>
 	`;
+
+	attachRefreshHandler(report, container);
 }
 
 window.renderScanResults = renderScanResults;

--- a/sast-platform/lambda_a/status.py
+++ b/sast-platform/lambda_a/status.py
@@ -8,6 +8,7 @@ so the frontend can fetch the report directly.
 """
 
 import logging
+from datetime import datetime, timedelta, timezone
 
 import boto3
 from botocore.exceptions import ClientError
@@ -33,10 +34,8 @@ def get_scan_status(scan_id: str, student_id: str, table_name: str, s3_bucket: s
 
     Returns a dict with:
       - status: PENDING | IN_PROGRESS | DONE | FAILED
-      - scan_id
-      - language
-      - created_at
-      - (when DONE) vuln_count, completed_at, report_url (presigned S3 URL)
+      - scan_id, language, created_at
+      - (when DONE) vuln_count, completed_at, report_url, report_url_expires_at
 
     Raises:
         ValueError  if scan_id not found or does not belong to student_id
@@ -68,6 +67,11 @@ def get_scan_status(scan_id: str, student_id: str, table_name: str, s3_bucket: s
         s3_key = item.get("s3_report_key")
         if s3_key:
             result["report_url"] = _generate_presigned_url(s3_bucket, s3_key)
+            # Tell the client exactly when this URL stops working so it can
+            # warn the user before they get a silent 403 from S3.
+            result["report_url_expires_at"] = (
+                datetime.now(timezone.utc) + timedelta(seconds=PRESIGNED_URL_EXPIRY)
+            ).isoformat()
 
     return result
 


### PR DESCRIPTION
## Summary

- **`status.py`**: DONE responses that include a `report_url` now also include `report_url_expires_at` (ISO 8601, `now + 3600 s`). Clients know exactly when the link stops working without having to guess.

- **`results.js`**: new `buildDownloadSection()` renders the download link with a human-readable expiry time. If the URL is already expired when the page renders, shows an "expired" warning instead of a broken link. Adds a **"Refresh link"** button that calls `window.pollStatus()` (from `app.js`) to re-fetch a fresh presigned URL and re-render — no page reload needed.

Closes #21

## Test plan

- [ ] DONE response includes `report_url_expires_at` ~1 hour from now
- [ ] Results page shows the expiry time next to the download link
- [ ] Returning to a page with an expired URL shows the expiry warning
- [ ] "Refresh link" button fetches a new URL and updates the link in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)