### PR TITLE
docs: add local dev guide, pytest config, and Makefile — closes #27

### DIFF
--- a/sast-platform/Makefile
+++ b/sast-platform/Makefile
@@ -1,0 +1,39 @@
+# Makefile — convenience targets for local development
+# Run from the sast-platform/ directory.
+
+.PHONY: install install-a install-b test test-unit test-no-scan test-integration lint help
+
+help:
+	@echo "Usage: make <target>"
+	@echo ""
+	@echo "  install        Install test deps for both Lambda A and B"
+	@echo "  install-a      Install Lambda A deps only"
+	@echo "  install-b      Install Lambda B deps only"
+	@echo "  test           Run unit + integration tests (no AWS needed)"
+	@echo "  test-unit      Run unit tests only"
+	@echo "  test-no-scan   Run unit tests, skip scanner (no bandit/semgrep needed)"
+	@echo "  test-integration  Run integration tests only"
+	@echo "  lint           Run bandit on lambda_a/ and lambda_b/"
+
+install: install-a install-b
+
+install-a:
+	pip install -r lambda_a/requirements.txt
+
+install-b:
+	pip install -r lambda_b/requirements.txt
+
+test:
+	pytest tests/unit tests/integration -v
+
+test-unit:
+	pytest tests/unit -v
+
+test-no-scan:
+	pytest tests/unit -v -k "not scanner"
+
+test-integration:
+	pytest tests/integration -v
+
+lint:
+	bandit -r lambda_a/ lambda_b/ -ll

--- a/sast-platform/README.md
+++ b/sast-platform/README.md
@@ -1,0 +1,203 @@
+# Student Assignment Security Checking Platform
+
+A serverless SAST pipeline: students submit code through a frontend, Lambda A validates and queues it, Lambda B runs Bandit/Semgrep and writes results to S3 + DynamoDB.
+
+```
+Browser → Lambda A (validate + queue) → SQS → Lambda B (scan) → S3 + DynamoDB
+```
+
+---
+
+## Local Development
+
+**No AWS account needed for unit and integration tests.** All AWS calls are intercepted by [moto](https://github.com/getmoto/moto), which emulates DynamoDB, SQS, and S3 in-process.
+
+### Prerequisites
+
+| Tool | Version | Required for |
+|------|---------|-------------|
+| Python | 3.12 | everything |
+| pip | any | installing deps |
+| bandit | `pip install bandit` | Lambda B scanner tests only |
+| semgrep | `pip install semgrep` | Lambda B scanner tests only |
+
+bandit and semgrep are **optional** — all other tests run without them. Skip scanner tests with `pytest -k "not scanner"`.
+
+---
+
+### Quick Start
+
+```bash
+# 1. Install test dependencies (covers both Lambda A and B)
+pip install -r lambda_a/requirements.txt
+pip install -r lambda_b/requirements.txt
+
+# 2. Run all unit tests — no AWS, no Docker, completes in seconds
+pytest tests/unit -v
+
+# 3. Skip scanner tests if bandit/semgrep are not installed locally
+pytest tests/unit -v -k "not scanner"
+```
+
+Or use Make:
+
+```bash
+make install       # install deps for both lambdas
+make test          # all unit + integration tests
+make test-unit     # unit tests only
+make test-no-scan  # unit tests, skip scanner (no bandit/semgrep needed)
+```
+
+---
+
+### Running Tests by Suite
+
+#### Unit tests — Lambda A
+
+Files: `tests/unit/test_validator.py`, `test_dispatcher.py`, `test_lambda_a.py`
+
+```bash
+pip install -r lambda_a/requirements.txt
+pytest tests/unit/test_validator.py tests/unit/test_dispatcher.py tests/unit/test_lambda_a.py -v
+```
+
+Covers: input validation, scan job creation, DynamoDB record shape, SQS message payload, error propagation.
+
+#### Unit tests — Lambda B
+
+Files: `tests/unit/test_result_parser.py`, `test_scanner.py`
+
+```bash
+pip install -r lambda_b/requirements.txt   # includes bandit + semgrep
+
+# result_parser tests need no external tools:
+pytest tests/unit/test_result_parser.py -v
+
+# scanner tests invoke bandit/semgrep as subprocesses:
+pytest tests/unit/test_scanner.py -v
+```
+
+Covers: Bandit/Semgrep output normalisation, severity mapping, finding counts.
+
+#### Integration tests
+
+Files: `tests/integration/`
+
+```bash
+pip install -r lambda_a/requirements.txt
+pip install -r lambda_b/requirements.txt
+pytest tests/integration -v
+```
+
+Wires Lambda A + Lambda B together through moto-backed SQS and DynamoDB. No real AWS needed.
+
+#### Load tests
+
+Files: `tests/load/locustfile.py`
+
+Requires a **live deployed stack**. Install locust and point it at your Lambda URL:
+
+```bash
+pip install locust
+locust -f tests/load/locustfile.py --host https://<your-lambda-function-url>
+```
+
+#### End-to-end tests
+
+Files: `tests/e2e/`
+
+Requires a fully deployed AWS environment:
+
+```bash
+export LAMBDA_URL="https://<your-function-url>"
+export STUDENT_ID="your-student-id"
+pytest tests/e2e -v
+```
+
+---
+
+### Environment Variables
+
+Unit and integration tests set all required env vars automatically inside moto fixtures. You do **not** need a `.env` file for local testing.
+
+For manual invocation or e2e tests, the Lambdas expect:
+
+**Lambda A**
+
+| Variable | Description |
+|----------|-------------|
+| `SQS_QUEUE_URL` | SQS queue URL |
+| `DYNAMODB_TABLE` | DynamoDB table name |
+| `S3_BUCKET` | S3 bucket for scan reports |
+
+**Lambda B**
+
+| Variable | Description |
+|----------|-------------|
+| `DYNAMODB_TABLE_NAME` | DynamoDB table name |
+| `S3_BUCKET_NAME` | S3 bucket for scan reports |
+
+---
+
+### How moto works
+
+moto intercepts all `boto3` calls and routes them to an in-memory AWS emulator. No real credentials are needed — the fixtures set dummy values that satisfy boto3's validation:
+
+```python
+monkeypatch.setenv("AWS_ACCESS_KEY_ID",     "testing")
+monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+monkeypatch.setenv("AWS_DEFAULT_REGION",    "us-east-1")
+```
+
+AWS state is isolated per test — each test function gets a fresh DynamoDB table, SQS queue, and S3 bucket, then it is torn down automatically.
+
+---
+
+## Project Structure
+
+```
+sast-platform/
+├── lambda_a/               # API handler (POST /scan, GET /status)
+│   ├── handler.py
+│   ├── validator.py
+│   ├── dispatcher.py
+│   ├── status.py
+│   └── requirements.txt    # runtime + test deps (boto3, pytest, moto)
+├── lambda_b/               # Scan engine (Bandit, Semgrep, ECS fallback)
+│   ├── handler.py
+│   ├── scanner.py
+│   ├── result_parser.py
+│   ├── s3_writer.py
+│   ├── ecs_handler.py
+│   └── requirements.txt    # runtime + test deps (bandit, semgrep, pytest, moto)
+├── frontend/               # Static HTML/CSS/JS frontend
+├── infrastructure/         # CloudFormation templates
+│   ├── dynamodb.yaml
+│   ├── sqs.yaml
+│   ├── cloudwatch.yaml
+│   └── ...
+├── scripts/                # Sequential deploy scripts
+├── tests/
+│   ├── unit/               # Fast, moto-backed, no AWS required
+│   ├── integration/        # Service-level, moto-backed, no AWS required
+│   ├── load/               # Locust load tests — needs live stack
+│   └── e2e/                # Full flow — needs live stack
+├── pytest.ini              # Test discovery config
+└── README.md
+```
+
+---
+
+## Deployment
+
+Deployment uses the shell scripts in `scripts/`. Run them in order from the `sast-platform/` directory:
+
+```bash
+bash scripts/01_setup_infra.sh       # CloudFormation stacks (DynamoDB, SQS, CloudWatch)
+bash scripts/02_deploy_lambda_a.sh   # Package and deploy Lambda A
+bash scripts/03_deploy_lambda_b.sh   # Package and deploy Lambda B
+bash scripts/04_upload_frontend.sh   # Upload static frontend to S3
+bash scripts/05_test_api.sh          # Smoke-test the live API
+```
+
+Each script prints the required AWS environment variables at the top if they are not set.

--- a/sast-platform/lambda_a/requirements.txt
+++ b/sast-platform/lambda_a/requirements.txt
@@ -7,4 +7,4 @@ boto3>=1.34.0
 
 # Test dependencies (not bundled in Lambda deployment package)
 pytest>=8.0.0
-moto[sqs,dynamodb]>=5.0.0
+moto[dynamodb,sqs,s3]>=5.0.0

--- a/sast-platform/lambda_b/requirements.txt
+++ b/sast-platform/lambda_b/requirements.txt
@@ -3,3 +3,7 @@ semgrep>=1.45.0
 boto3>=1.28.0
 botocore>=1.31.0
 typing-extensions>=4.8.0
+
+# Test dependencies (not bundled in Lambda deployment package)
+pytest>=8.0.0
+moto[dynamodb,sqs,s3]>=5.0.0

--- a/sast-platform/pytest.ini
+++ b/sast-platform/pytest.ini
@@ -1,0 +1,13 @@
+[pytest]
+# Run unit and integration tests by default.
+# Load and e2e tests require a live AWS stack — run them explicitly.
+testpaths = tests/unit tests/integration
+
+# Show short tracebacks and print local variables on failure.
+addopts = --tb=short
+
+# Markers used across the test suite.
+markers =
+    scanner: tests that invoke bandit or semgrep as subprocesses (skip if not installed)
+    e2e: end-to-end tests that require a live AWS deployment
+    load: load tests that require a live AWS deployment

--- a/sast-platform/tests/unit/conftest.py
+++ b/sast-platform/tests/unit/conftest.py
@@ -1,11 +1,17 @@
 # conftest.py — pytest configuration for unit tests
 #
-# Adds lambda_a/ to sys.path so test files can import validator, dispatcher, etc.
-# This file is loaded automatically by pytest before any test in this directory.
+# Adds lambda_a/ and lambda_b/ to sys.path so test files can import
+# validator, dispatcher, result_parser, scanner, etc. without installing
+# the packages. Loaded automatically by pytest before any test in this directory.
 
 import sys
 import os
 
-LAMBDA_A_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "lambda_a")
-if LAMBDA_A_DIR not in sys.path:
-    sys.path.insert(0, os.path.abspath(LAMBDA_A_DIR))
+_HERE = os.path.dirname(__file__)
+
+LAMBDA_A_DIR = os.path.abspath(os.path.join(_HERE, "..", "..", "lambda_a"))
+LAMBDA_B_DIR = os.path.abspath(os.path.join(_HERE, "..", "..", "lambda_b"))
+
+for _dir in (LAMBDA_A_DIR, LAMBDA_B_DIR):
+    if _dir not in sys.path:
+        sys.path.insert(0, _dir)


### PR DESCRIPTION
## Summary

- **README.md** (was empty): full local dev guide covering quick-start, per-suite test instructions, env var reference, moto explanation, project structure, and deployment steps.
- **pytest.ini**: sets `testpaths = tests/unit tests/integration` and `--tb=short` so running `pytest` from `sast-platform/` works out of the box without extra flags.
- **Makefile**: `make install / test / test-unit / test-no-scan / test-integration / lint` — one command to go from clone to passing tests.
- **lambda_b/requirements.txt**: adds `pytest>=8.0.0` and `moto[dynamodb,sqs,s3]>=5.0.0` — these were entirely missing, so the existing lambda_b unit tests had no declared way to install their test runner or AWS mock.
- **lambda_a/requirements.txt**: expands `moto[sqs,dynamodb]` to `moto[dynamodb,sqs,s3]` so S3 fixtures work without a separate install step.
- **tests/unit/conftest.py**: inserts `lambda_b/` into `sys.path` alongside `lambda_a/`, so lambda_b modules (`result_parser`, `scanner`, etc.) are importable without each test file patching the path itself.

## Test plan
- [ ] `pip install -r lambda_a/requirements.txt && pip install -r lambda_b/requirements.txt`
- [ ] `pytest tests/unit -v` — all tests pass (or only scanner tests fail if bandit/semgrep not installed)
- [ ] `pytest tests/unit -v -k "not scanner"` — passes with zero external tools beyond Python
- [ ] `make install && make test-no-scan` — same result via Makefile
- [ ] `make test-unit` — same as direct pytest invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)