### PR TITLE
fix: review corrections for PR #52 — ECS fallback and subprocess timeout

### DIFF
--- a/sast-platform/lambda_b/ecs_handler.py
+++ b/sast-platform/lambda_b/ecs_handler.py
@@ -9,7 +9,7 @@ import logging
 import boto3
 
 from scanner import scan_code_with_timeout
-from result_parser import ResultParser
+from result_parser import normalize_result
 from s3_writer import write_scan_result_to_s3, S3WriteError
 from botocore.exceptions import ClientError
 
@@ -66,6 +66,7 @@ def main():
         logger.info(f"Start scan task: {scan_id}")
 
         # fetch source code (S3 key preferred, inline env var as fallback)
+        s3_code_key  = os.environ.get("S3_CODE_KEY")
         code_content = _fetch_code(s3_bucket_name)
 
         # connect to table
@@ -78,7 +79,8 @@ def main():
             language,
             student_id,
             table,
-            s3_bucket_name
+            s3_bucket_name,
+            s3_code_key=s3_code_key,
         )
 
         if result["success"]:
@@ -93,7 +95,19 @@ def main():
         sys.exit(1)
 
 
-def process_ecs_scan(scan_id, code, language, student_id, table, s3_bucket_name):
+def _delete_uploaded_code(s3_bucket_name: str, s3_code_key: str) -> None:
+    """Delete uploaded source code from S3 after scanning — data privacy cleanup."""
+    if not s3_code_key:
+        return
+    try:
+        s3_client.delete_object(Bucket=s3_bucket_name, Key=s3_code_key)
+        logger.info(f"Deleted uploaded code from S3 - key: {s3_code_key}")
+    except Exception as e:
+        logger.warning(f"Failed to delete uploaded code - key: {s3_code_key}, error: {str(e)}")
+
+
+def process_ecs_scan(scan_id, code, language, student_id, table, s3_bucket_name,
+                     s3_code_key=None):
     try:
         logger.info(f"Running scan for {scan_id}")
 
@@ -103,10 +117,17 @@ def process_ecs_scan(scan_id, code, language, student_id, table, s3_bucket_name)
         logger.info(f"Parsing result for {scan_id}")
 
         # format the scan result
-        parsed_result = ResultParser.parse_scan_result(raw_scan_result)
+        if 'error' in raw_scan_result:
+            raise RuntimeError(f"Scanner error: {raw_scan_result['error']}")
+        parsed_result = normalize_result(
+            tool=raw_scan_result['tool'],
+            raw_output=raw_scan_result.get('raw_output', {}),
+            scan_id=scan_id,
+            language=language,
+        )
 
         # count vulnerabilities
-        vuln_count = ResultParser.calculate_vuln_count(parsed_result)
+        vuln_count = parsed_result['vuln_count']
 
         logger.info(f"Saving to S3 for {scan_id}")
 
@@ -130,6 +151,9 @@ def process_ecs_scan(scan_id, code, language, student_id, table, s3_bucket_name)
 
         logger.info(f"Done: {scan_id}, found {vuln_count} issues")
 
+        # Data privacy: delete uploaded source code from S3 after successful scan
+        _delete_uploaded_code(s3_bucket_name, s3_code_key)
+
         return {
             "success": True,
             "scan_id": scan_id,
@@ -146,6 +170,7 @@ def process_ecs_scan(scan_id, code, language, student_id, table, s3_bucket_name)
         except Exception as db_error:
             logger.error(f"DB update also failed: {str(db_error)}")
 
+        _delete_uploaded_code(s3_bucket_name, s3_code_key)
         return {
             "success": False,
             "error": f"S3 write failed: {str(e)}"
@@ -160,6 +185,7 @@ def process_ecs_scan(scan_id, code, language, student_id, table, s3_bucket_name)
         except Exception as db_error:
             logger.error(f"DB update also failed: {str(db_error)}")
 
+        _delete_uploaded_code(s3_bucket_name, s3_code_key)
         return {
             "success": False,
             "error": str(e)

--- a/sast-platform/lambda_b/handler.py
+++ b/sast-platform/lambda_b/handler.py
@@ -14,7 +14,7 @@ from typing import Dict, Any, List
 from botocore.exceptions import ClientError
 
 from scanner import scan_code_with_timeout
-from result_parser import ResultParser
+from result_parser import normalize_result
 from s3_writer import write_scan_result_to_s3, get_s3_bucket_from_env, S3WriteError
 
 # Configure logging
@@ -159,16 +159,31 @@ def process_scan_request(scan_id: str, code: str, language: str, student_id: str
                 f"— routing to ECS Fargate - scan_id: {scan_id}"
             )
             update_scan_status(table, student_id, scan_id, 'ECS_QUEUED')
-            return handle_ecs_fallback(scan_id, language, student_id, s3_code_key)
+            ecs_result = handle_ecs_fallback(scan_id, language, student_id, s3_code_key)
+            if not ecs_result['success']:
+                # ECS launch failed — mark FAILED so the scan doesn't stay stuck in ECS_QUEUED
+                try:
+                    update_scan_status(table, student_id, scan_id, 'FAILED',
+                                       error_message=ecs_result['error'])
+                except Exception as db_err:
+                    logger.error(f"Failed to update FAILED status after ECS launch error - scan_id: {scan_id}, error: {str(db_err)}")
+            return ecs_result
 
         # Step 1: Execute security scan
         logger.info(f"Starting scan - scan_id: {scan_id}")
         raw_scan_result = scan_code_with_timeout(code, language, scan_id, timeout=300)
-        
+
         # Step 2: Parse scan results
         logger.info(f"Parsing scan results - scan_id: {scan_id}")
-        parsed_result = ResultParser.parse_scan_result(raw_scan_result)
-        vuln_count = ResultParser.calculate_vuln_count(parsed_result)
+        if 'error' in raw_scan_result:
+            raise RuntimeError(f"Scanner error: {raw_scan_result['error']}")
+        parsed_result = normalize_result(
+            tool=raw_scan_result['tool'],
+            raw_output=raw_scan_result.get('raw_output', {}),
+            scan_id=scan_id,
+            language=language,
+        )
+        vuln_count = parsed_result['vuln_count']
         
         # Step 3: Write to S3
         logger.info(f"Writing scan report to S3 - scan_id: {scan_id}")

--- a/sast-platform/lambda_b/scanner.py
+++ b/sast-platform/lambda_b/scanner.py
@@ -20,7 +20,7 @@ class SecurityScanner:
     def __init__(self):
         self.temp_dir = None
     
-    def scan_code(self, code: str, language: str, scan_id: str):
+    def scan_code(self, code: str, language: str, scan_id: str, timeout: int = 300):
         """
         main entry
         decide which tool to use based on language
@@ -29,12 +29,12 @@ class SecurityScanner:
             # create a temp folder to store code file；will be cleaned up after scan
             with tempfile.TemporaryDirectory() as temp_dir:
                 self.temp_dir = temp_dir
-                
+
                 # pick scanner based on language
                 if language.lower() == 'python':
-                    return self._scan_with_bandit(code, scan_id)
+                    return self._scan_with_bandit(code, scan_id, timeout)
                 elif language.lower() in ['java', 'javascript', 'js']:
-                    return self._scan_with_semgrep(code, language, scan_id)
+                    return self._scan_with_semgrep(code, language, scan_id, timeout)
                 else:
                     raise ValueError(f"Unsupported language type: {language}")
                     
@@ -49,7 +49,7 @@ class SecurityScanner:
                 'summary': {'HIGH': 0, 'MEDIUM': 0, 'LOW': 0}
             }
     
-    def _scan_with_bandit(self, code: str, scan_id: str):
+    def _scan_with_bandit(self, code: str, scan_id: str, timeout: int = 300):
         """
         Use Bandit to scan Python code
         """
@@ -73,10 +73,10 @@ class SecurityScanner:
                 cmd,
                 capture_output=True,
                 text=True,
-                timeout=300,  # 5 minute timeout
+                timeout=timeout,
                 cwd=self.temp_dir
             )
-            
+
             # bandit return code:
             # 0 -> no issue
             # 1 -> issues found
@@ -118,7 +118,7 @@ class SecurityScanner:
         except Exception as e:
             raise RuntimeError(f"Bandit scan exception: {str(e)}")
     
-    def _scan_with_semgrep(self, code: str, language: str, scan_id: str):
+    def _scan_with_semgrep(self, code: str, language: str, scan_id: str, timeout: int = 300):
         """
         use semgrep for java / js
         """
@@ -153,10 +153,10 @@ class SecurityScanner:
                 cmd,
                 capture_output=True,
                 text=True,
-                timeout=300,  # 5 minute timeout
+                timeout=timeout,
                 cwd=self.temp_dir
             )
-            
+
             # Semgrep return codes
             if result.returncode >= 2:
                 raise RuntimeError(f"Semgrep execution failed: {result.stderr}")
@@ -188,8 +188,9 @@ class SecurityScanner:
 
 def scan_code_with_timeout(code: str, language: str, scan_id: str, timeout: int = 300):
     """
-    simple wrapper for scanner
-    timeout not really enforced yet
+    Wrapper that runs the appropriate scanner and enforces a subprocess timeout.
+    The timeout is forwarded all the way to subprocess.run so the scanner process
+    is killed if it exceeds the given number of seconds.
     """
     scanner = SecurityScanner()
-    return scanner.scan_code(code, language, scan_id)
+    return scanner.scan_code(code, language, scan_id, timeout)


### PR DESCRIPTION
## Summary

Review fixes for PR #52 ([Jiahua] fix #12: wire ECS fallback and enforce subprocess timeout).

**5 issues found and fixed:**

1. **`scanner.py` — timeout never propagated (scanner.py missing from PR diff)**: `scan_code_with_timeout` accepted a `timeout` arg but dropped it — both `subprocess.run` calls still used hardcoded `timeout=300`. The PR description claimed this was fixed but `scanner.py` was not in the diff. Threaded timeout through the full call chain: `scan_code_with_timeout → scan_code → _scan_with_bandit / _scan_with_semgrep → subprocess.run`.

2. **`handler.py` — `ResultParser` `ImportError` at Lambda cold start**: `from result_parser import ResultParser` fails at import — only `normalize_result()` is exported. Replaced with `normalize_result()` + scanner error-dict check before parsing.

3. **`ecs_handler.py` — same `ResultParser` `ImportError`**: ECS task would crash immediately at startup. Same fix applied.

4. **`handler.py` — ECS launch failure leaves scan stuck in `ECS_QUEUED` forever**: `process_scan_request` set status to `ECS_QUEUED` then returned `handle_ecs_fallback()` directly. If the ECS `RunTask` call failed, the scan stayed `ECS_QUEUED` indefinitely. Fixed: check `ecs_result['success']` and mark `FAILED` on failure.

5. **`ecs_handler.py` — no S3 cleanup after ECS scan**: ECS task fetched code from S3 but never deleted it after finishing. Added `_delete_uploaded_code()` helper and call it in all three exit paths (success, `S3WriteError`, general exception).

## Test plan
- [ ] Submit a 600 s timeout — verify it reaches `subprocess.run` (scanner actually killed at 600 s)
- [ ] Submit file > 250 KB with ECS launch intentionally broken — verify DynamoDB shows FAILED, not ECS_QUEUED
- [ ] Run ECS task — verify uploaded code deleted from S3 on both success and failure

Closes #12 (via original PR #52 + these review corrections)

🤖 Generated with [Claude Code](https://claude.com/claude-code)