### PR TITLE
fix: wire ECS fallback and enforce subprocess timeout — closes #12

### DIFF
--- a/sast-platform/lambda_b/ecs_handler.py
+++ b/sast-platform/lambda_b/ecs_handler.py
@@ -9,42 +9,53 @@ import logging
 import boto3
 
 from scanner import scan_code_with_timeout
-from result_parser import ResultParser
+from result_parser import normalize_result
 from s3_writer import write_scan_result_to_s3, S3WriteError
 from botocore.exceptions import ClientError
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger()
 
-# connect to DynamoDB
+# connect to DynamoDB and S3
 dynamodb = boto3.resource("dynamodb")
+s3_client = boto3.client("s3")
+
+
+def _fetch_code(s3_bucket_name: str) -> str:
+    """
+    Resolve the source code to scan.
+
+    Priority:
+    1. S3_CODE_KEY env var — code was uploaded to S3 (S3-staging path, issue #14).
+       Preferred for large submissions because env vars are limited to ~32 KB.
+    2. CODE_CONTENT env var — code passed inline (legacy / small submissions).
+    """
+    s3_code_key = os.environ.get("S3_CODE_KEY")
+    if s3_code_key:
+        logger.info(f"Fetching code from S3: {s3_code_key}")
+        response = s3_client.get_object(Bucket=s3_bucket_name, Key=s3_code_key)
+        return response["Body"].read().decode("utf-8")
+
+    code_content = os.environ.get("CODE_CONTENT")
+    if code_content:
+        return code_content
+
+    raise ValueError("Neither S3_CODE_KEY nor CODE_CONTENT environment variable is set")
 
 
 def main():
     try:
         # required info from env variables
-        scan_id = os.environ.get("SCAN_ID")
+        scan_id    = os.environ.get("SCAN_ID")
         student_id = os.environ.get("STUDENT_ID")
-        language = os.environ.get("LANGUAGE")
-        code_content = os.environ.get("CODE_CONTENT")
+        language   = os.environ.get("LANGUAGE")
 
-        # check if anything is missing
-        if not scan_id or not student_id or not language or not code_content:
-            missing = []
-
-            if not scan_id:
-                missing.append("SCAN_ID")
-            if not student_id:
-                missing.append("STUDENT_ID")
-            if not language:
-                missing.append("LANGUAGE")
-            if not code_content:
-                missing.append("CODE_CONTENT")
-
+        missing = [name for name, val in [("SCAN_ID", scan_id), ("STUDENT_ID", student_id), ("LANGUAGE", language)] if not val]
+        if missing:
             raise ValueError("Missing required environment variables: " + ", ".join(missing))
 
         # get table and bucket names
-        table_name = os.environ.get("DYNAMODB_TABLE_NAME")
+        table_name     = os.environ.get("DYNAMODB_TABLE_NAME")
         s3_bucket_name = os.environ.get("S3_BUCKET_NAME")
 
         if not table_name:
@@ -53,6 +64,10 @@ def main():
             raise ValueError("S3_BUCKET_NAME is not set")
 
         logger.info(f"Start scan task: {scan_id}")
+
+        # fetch source code (S3 key preferred, inline env var as fallback)
+        s3_code_key  = os.environ.get("S3_CODE_KEY")
+        code_content = _fetch_code(s3_bucket_name)
 
         # connect to table
         table = dynamodb.Table(table_name)
@@ -64,7 +79,8 @@ def main():
             language,
             student_id,
             table,
-            s3_bucket_name
+            s3_bucket_name,
+            s3_code_key=s3_code_key,
         )
 
         if result["success"]:
@@ -79,7 +95,19 @@ def main():
         sys.exit(1)
 
 
-def process_ecs_scan(scan_id, code, language, student_id, table, s3_bucket_name):
+def _delete_uploaded_code(s3_bucket_name: str, s3_code_key: str) -> None:
+    """Delete uploaded source code from S3 after scanning — data privacy cleanup."""
+    if not s3_code_key:
+        return
+    try:
+        s3_client.delete_object(Bucket=s3_bucket_name, Key=s3_code_key)
+        logger.info(f"Deleted uploaded code from S3 - key: {s3_code_key}")
+    except Exception as e:
+        logger.warning(f"Failed to delete uploaded code - key: {s3_code_key}, error: {str(e)}")
+
+
+def process_ecs_scan(scan_id, code, language, student_id, table, s3_bucket_name,
+                     s3_code_key=None):
     try:
         logger.info(f"Running scan for {scan_id}")
 
@@ -89,10 +117,17 @@ def process_ecs_scan(scan_id, code, language, student_id, table, s3_bucket_name)
         logger.info(f"Parsing result for {scan_id}")
 
         # format the scan result
-        parsed_result = ResultParser.parse_scan_result(raw_scan_result)
+        if 'error' in raw_scan_result:
+            raise RuntimeError(f"Scanner error: {raw_scan_result['error']}")
+        parsed_result = normalize_result(
+            tool=raw_scan_result['tool'],
+            raw_output=raw_scan_result.get('raw_output', {}),
+            scan_id=scan_id,
+            language=language,
+        )
 
         # count vulnerabilities
-        vuln_count = ResultParser.calculate_vuln_count(parsed_result)
+        vuln_count = parsed_result['vuln_count']
 
         logger.info(f"Saving to S3 for {scan_id}")
 
@@ -116,6 +151,9 @@ def process_ecs_scan(scan_id, code, language, student_id, table, s3_bucket_name)
 
         logger.info(f"Done: {scan_id}, found {vuln_count} issues")
 
+        # Data privacy: delete uploaded source code from S3 after successful scan
+        _delete_uploaded_code(s3_bucket_name, s3_code_key)
+
         return {
             "success": True,
             "scan_id": scan_id,
@@ -132,6 +170,7 @@ def process_ecs_scan(scan_id, code, language, student_id, table, s3_bucket_name)
         except Exception as db_error:
             logger.error(f"DB update also failed: {str(db_error)}")
 
+        _delete_uploaded_code(s3_bucket_name, s3_code_key)
         return {
             "success": False,
             "error": f"S3 write failed: {str(e)}"
@@ -146,6 +185,7 @@ def process_ecs_scan(scan_id, code, language, student_id, table, s3_bucket_name)
         except Exception as db_error:
             logger.error(f"DB update also failed: {str(db_error)}")
 
+        _delete_uploaded_code(s3_bucket_name, s3_code_key)
         return {
             "success": False,
             "error": str(e)

--- a/sast-platform/lambda_b/handler.py
+++ b/sast-platform/lambda_b/handler.py
@@ -28,6 +28,11 @@ from s3_writer import write_scan_result_to_s3, get_s3_bucket_from_env, S3WriteEr
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
+# Code size threshold for ECS fallback.
+# Submissions larger than this are offloaded to ECS Fargate instead of
+# being scanned inline, avoiding Lambda timeout/memory limits.
+LAMBDA_CODE_SIZE_LIMIT = 250_000  # ~250 KB
+
 # Initialize AWS clients
 dynamodb = boto3.resource('dynamodb')
 sqs = boto3.client('sqs')
@@ -154,7 +159,26 @@ def process_scan_request(scan_id: str, language: str, student_id: str,
         logger.info(f"Fetching code from S3 - scan_id: {scan_id}, key: {s3_code_key}")
         code = _fetch_code_from_s3(s3_bucket_name, s3_code_key)
 
-        # Step 2: Execute security scan
+        # Route large submissions to ECS Fargate to avoid Lambda timeout/OOM.
+        # Use byte length — len(str) counts characters, not bytes.
+        code_bytes = len(code.encode('utf-8'))
+        if code_bytes > LAMBDA_CODE_SIZE_LIMIT:
+            logger.info(
+                f"Code size {code_bytes} bytes exceeds {LAMBDA_CODE_SIZE_LIMIT} limit "
+                f"— routing to ECS Fargate - scan_id: {scan_id}"
+            )
+            update_scan_status(table, student_id, scan_id, 'ECS_QUEUED')
+            ecs_result = handle_ecs_fallback(scan_id, language, student_id, s3_code_key)
+            if not ecs_result['success']:
+                # ECS launch failed — mark FAILED so the scan doesn't stay stuck in ECS_QUEUED
+                try:
+                    update_scan_status(table, student_id, scan_id, 'FAILED',
+                                       error_message=ecs_result['error'])
+                except Exception as db_err:
+                    logger.error(f"Failed to update FAILED status after ECS launch error - scan_id: {scan_id}, error: {str(db_err)}")
+            return ecs_result
+
+        # Step 2: Execute security scan (inline for small submissions)
         logger.info(f"Starting scan - scan_id: {scan_id}")
         raw_scan_result = scan_code_with_timeout(code, language, scan_id, timeout=300)
 
@@ -301,35 +325,45 @@ def update_scan_status(table: Any, student_id: str, scan_id: str, status: str,
         raise
 
 
-def handle_ecs_fallback(scan_id: str, code: str, language: str, student_id: str) -> Dict[str, Any]:
+def handle_ecs_fallback(scan_id: str, language: str, student_id: str,
+                       s3_code_key: str) -> Dict[str, Any]:
     """
-    Handle ECS Fargate fallback logic for large files or complex scans
-    Used when Lambda memory is insufficient or execution time exceeds limit
-    
+    Launch an ECS Fargate task to handle a scan that is too large for Lambda.
+
+    The source code is referenced via s3_code_key (an S3 object key) rather
+    than being passed inline.  ECS container env var overrides are capped at
+    ~8 KB per entry, so passing raw code strings for large files would cause
+    the ECS API call to fail.  ecs_handler.py reads S3_CODE_KEY and fetches
+    the code from S3 directly.
+
     Args:
-        scan_id: Scan ID
-        code: Code content
-        language: Code language
-        student_id: Student ID
-        
+        scan_id:     Scan task ID.
+        language:    Programming language of the submission.
+        student_id:  Student who submitted the scan.
+        s3_code_key: S3 object key for the uploaded source code (set by
+                     Lambda A via S3-staging, PR #48).
+
     Returns:
-        ECS task launch result
+        Dict with 'success' bool and 'task_arn' or 'error'.
     """
+    if not s3_code_key:
+        logger.error(f"ECS fallback requires s3_code_key but none provided - scan_id: {scan_id}")
+        return {'success': False, 'error': 'ECS fallback requires s3_code_key (S3-staging not active)'}
+
     try:
-        ecs_client = boto3.client('ecs')
-        cluster_name = os.environ.get('ECS_CLUSTER_NAME', 'sast-platform-cluster')
+        ecs_client      = boto3.client('ecs')
+        cluster_name    = os.environ.get('ECS_CLUSTER_NAME', 'sast-platform-cluster')
         task_definition = os.environ.get('ECS_TASK_DEFINITION', 'sast-scanner-task')
-        
-        # Launch ECS task
+
         response = ecs_client.run_task(
             cluster=cluster_name,
             taskDefinition=task_definition,
             launchType='FARGATE',
             networkConfiguration={
                 'awsvpcConfiguration': {
-                    'subnets': os.environ.get('ECS_SUBNETS', '').split(','),
-                    'securityGroups': os.environ.get('ECS_SECURITY_GROUPS', '').split(','),
-                    'assignPublicIp': 'ENABLED'
+                    'subnets':          os.environ.get('ECS_SUBNETS', '').split(','),
+                    'securityGroups':   os.environ.get('ECS_SECURITY_GROUPS', '').split(','),
+                    'assignPublicIp':   'ENABLED',
                 }
             },
             overrides={
@@ -337,28 +371,30 @@ def handle_ecs_fallback(scan_id: str, code: str, language: str, student_id: str)
                     {
                         'name': 'scanner-container',
                         'environment': [
-                            {'name': 'SCAN_ID', 'value': scan_id},
-                            {'name': 'STUDENT_ID', 'value': student_id},
-                            {'name': 'LANGUAGE', 'value': language},
-                            {'name': 'CODE_CONTENT', 'value': code}
+                            {'name': 'SCAN_ID',      'value': scan_id},
+                            {'name': 'STUDENT_ID',   'value': student_id},
+                            {'name': 'LANGUAGE',     'value': language},
+                            # Pass the S3 key, not the raw code.
+                            # ecs_handler._fetch_code() downloads it from S3.
+                            {'name': 'S3_CODE_KEY',  'value': s3_code_key},
                         ]
                     }
                 ]
             }
         )
-        
+
         task_arn = response['tasks'][0]['taskArn']
         logger.info(f"ECS task launched - scan_id: {scan_id}, task_arn: {task_arn}")
-        
+
         return {
             'success': True,
             'task_arn': task_arn,
-            'message': 'ECS task launched, will complete scan asynchronously'
+            'message': 'ECS task launched, scan will complete asynchronously',
         }
-        
+
     except Exception as e:
         logger.error(f"ECS task launch failed - scan_id: {scan_id}, error: {str(e)}")
         return {
             'success': False,
-            'error': f"ECS task launch failed: {str(e)}"
+            'error': f"ECS task launch failed: {str(e)}",
         }


### PR DESCRIPTION
Review fixes for PR #52 — ECS fallback and subprocess timeout (issue #12).

**handler.py:**
- Add LAMBDA_CODE_SIZE_LIMIT = 250_000 (~250 KB); after fetching code from S3, check byte size and route to ECS Fargate if it exceeds the threshold
- Mark DynamoDB FAILED (not stuck in ECS_QUEUED) when ECS launch fails
- Rewrite handle_ecs_fallback() to pass S3_CODE_KEY instead of raw CODE_CONTENT env var (env var cap ~8 KB; large files must stay in S3); add guard returning failure when s3_code_key is absent

**ecs_handler.py:**
- Add _fetch_code() helper: reads from S3_CODE_KEY env var (preferred for large files) with fallback to CODE_CONTENT (legacy/small)
- Replace broken ResultParser import with normalize_result(); add scanner error-dict check before parsing
- Add _delete_uploaded_code() for data-privacy cleanup; call it on all exit paths (success, S3WriteError, Exception)

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)