### PR TITLE
docs: add local dev guide, pytest config, and Makefile — closes #27

### DIFF
--- a/sast-platform/Makefile
+++ b/sast-platform/Makefile
@@ -1,0 +1,39 @@
+# Makefile — convenience targets for local development
+# Run from the sast-platform/ directory.
+
+.PHONY: install install-a install-b test test-unit test-no-scan test-integration lint help
+
+help:
+	@echo "Usage: make <target>"
+	@echo ""
+	@echo "  install        Install test deps for both Lambda A and B"
+	@echo "  install-a      Install Lambda A deps only"
+	@echo "  install-b      Install Lambda B deps only"
+	@echo "  test           Run unit + integration tests (no AWS needed)"
+	@echo "  test-unit      Run unit tests only"
+	@echo "  test-no-scan   Run unit tests, skip scanner (no bandit/semgrep needed)"
+	@echo "  test-integration  Run integration tests only"
+	@echo "  lint           Run bandit on lambda_a/ and lambda_b/"
+
+install: install-a install-b
+
+install-a:
+	pip install -r lambda_a/requirements.txt
+
+install-b:
+	pip install -r lambda_b/requirements.txt
+
+test:
+	pytest tests/unit tests/integration -v
+
+test-unit:
+	pytest tests/unit -v
+
+test-no-scan:
+	pytest tests/unit -v -k "not scanner"
+
+test-integration:
+	pytest tests/integration -v
+
+lint:
+	bandit -r lambda_a/ lambda_b/ -ll

--- a/sast-platform/README.md
+++ b/sast-platform/README.md
@@ -138,11 +138,55 @@ Headers:
 
 ## Local Development & Testing
 
-### Unit tests (no AWS needed)
+**No AWS account needed for unit and integration tests.** All AWS calls are intercepted by [moto](https://github.com/getmoto/moto), which emulates DynamoDB, SQS, and S3 in-process.
+
+### Prerequisites
+
+| Tool | Version | Required for |
+|------|---------|-------------|
+| Python | 3.12+ | everything |
+| pip | any | installing deps |
+| bandit | `pip install bandit` | Lambda B scanner tests only |
+| semgrep | `pip install semgrep` | Lambda B scanner tests only |
+
+bandit and semgrep are **optional** — all other tests run without them. Skip scanner tests with `pytest -k "not scanner"`.
+
+### Quick Start
 
 ```bash
-pip install boto3 pytest "moto[sqs,dynamodb,s3]>=5.0.0"
-pytest tests/unit/ -v
+# 1. Install test dependencies (covers both Lambda A and B)
+pip install -r lambda_a/requirements.txt
+pip install -r lambda_b/requirements.txt
+
+# 2. Run all unit tests — no AWS, no Docker, completes in seconds
+pytest tests/unit -v
+
+# 3. Skip scanner tests if bandit/semgrep are not installed locally
+pytest tests/unit -v -k "not scanner"
+```
+
+Or use Make:
+
+```bash
+make install       # install deps for both lambdas
+make test          # all unit + integration tests
+make test-unit     # unit tests only
+make test-no-scan  # unit tests, skip scanner (no bandit/semgrep needed)
+```
+
+### Unit tests — Lambda A
+
+```bash
+pip install -r lambda_a/requirements.txt
+pytest tests/unit/test_validator.py tests/unit/test_dispatcher.py -v
+```
+
+### Unit tests — Lambda B
+
+```bash
+pip install -r lambda_b/requirements.txt
+pytest tests/unit/test_result_parser.py -v          # no external tools needed
+pytest tests/unit/test_scanner.py -v                # requires bandit + semgrep
 ```
 
 ### Integration tests (moto-backed pipeline)
@@ -164,6 +208,57 @@ pip install locust
 locust -f tests/load/locustfile.py \
   --host=https://<LAMBDA_URL> \
   --users=30 --spawn-rate=5 --run-time=2m --headless
+```
+
+### Environment Variables
+
+Unit and integration tests set all required env vars automatically inside moto fixtures — no `.env` file needed.
+
+**Lambda A**
+
+| Variable | Description |
+|----------|-------------|
+| `SQS_QUEUE_URL` | SQS queue URL |
+| `DYNAMODB_TABLE` | DynamoDB table name |
+| `S3_BUCKET` | S3 bucket for scan reports |
+
+**Lambda B**
+
+| Variable | Description |
+|----------|-------------|
+| `DYNAMODB_TABLE_NAME` | DynamoDB table name |
+| `S3_BUCKET_NAME` | S3 bucket for scan reports |
+
+### Project Structure
+
+```
+sast-platform/
+├── lambda_a/               # API handler (POST /scan, GET /status, GET /history)
+│   ├── handler.py
+│   ├── validator.py
+│   ├── dispatcher.py
+│   ├── status.py
+│   ├── auth.py             # X-Student-Key API-key authentication
+│   └── requirements.txt    # runtime + test deps (boto3, pytest, moto)
+├── lambda_b/               # Scan engine (Bandit, Semgrep, ECS fallback)
+│   ├── handler.py
+│   ├── scanner.py
+│   ├── result_parser.py
+│   ├── s3_writer.py
+│   ├── ecs_handler.py      # ECS Fargate fallback for large submissions
+│   ├── Dockerfile          # Container image (bypasses 250MB zip limit)
+│   └── requirements.txt    # runtime + test deps (bandit, semgrep, pytest, moto)
+├── frontend/               # Static HTML/CSS/JS frontend
+├── infrastructure/         # CloudFormation templates
+├── scripts/                # Sequential deploy scripts
+├── tests/
+│   ├── unit/               # Fast, moto-backed, no AWS required
+│   ├── integration/        # Service-level, moto-backed, no AWS required
+│   ├── load/               # Locust load tests — needs live stack
+│   └── e2e/                # Full flow — needs live stack
+├── pytest.ini              # Test discovery config
+├── Makefile                # Dev convenience targets
+└── README.md
 ```
 
 ---

--- a/sast-platform/lambda_a/requirements.txt
+++ b/sast-platform/lambda_a/requirements.txt
@@ -7,4 +7,4 @@ boto3==1.34.0
 
 # Test dependencies (not bundled in Lambda deployment package)
 pytest==8.0.0
-moto[sqs,dynamodb]==5.0.0
+moto[sqs,dynamodb,s3]==5.0.0

--- a/sast-platform/lambda_b/requirements.txt
+++ b/sast-platform/lambda_b/requirements.txt
@@ -3,3 +3,7 @@ semgrep==1.45.0
 boto3==1.34.0
 botocore==1.34.0
 typing-extensions==4.9.0
+
+# Test dependencies (not bundled in Lambda deployment package)
+pytest==8.0.0
+moto[dynamodb,sqs,s3]==5.0.0

--- a/sast-platform/pytest.ini
+++ b/sast-platform/pytest.ini
@@ -1,0 +1,13 @@
+[pytest]
+# Run unit and integration tests by default.
+# Load and e2e tests require a live AWS stack — run them explicitly.
+testpaths = tests/unit tests/integration
+
+# Show short tracebacks and print local variables on failure.
+addopts = --tb=short
+
+# Markers used across the test suite.
+markers =
+    scanner: tests that invoke bandit or semgrep as subprocesses (skip if not installed)
+    e2e: end-to-end tests that require a live AWS deployment
+    load: load tests that require a live AWS deployment

--- a/sast-platform/tests/conftest.py
+++ b/sast-platform/tests/conftest.py
@@ -1,0 +1,18 @@
+# conftest.py — top-level pytest configuration
+#
+# Adds lambda_a/ and lambda_b/ to sys.path so all test suites (unit,
+# integration) can import validator, dispatcher, result_parser, scanner, etc.
+# without installing the packages. Loaded automatically by pytest before any
+# test in this directory or its subdirectories.
+
+import sys
+import os
+
+_HERE = os.path.dirname(__file__)
+
+LAMBDA_A_DIR = os.path.abspath(os.path.join(_HERE, "..", "lambda_a"))
+LAMBDA_B_DIR = os.path.abspath(os.path.join(_HERE, "..", "lambda_b"))
+
+for _dir in (LAMBDA_A_DIR, LAMBDA_B_DIR):
+    if _dir not in sys.path:
+        sys.path.insert(0, _dir)

--- a/sast-platform/tests/unit/conftest.py
+++ b/sast-platform/tests/unit/conftest.py
@@ -1,19 +1,7 @@
 # conftest.py — pytest configuration for unit tests
 #
-# Adds lambda_a/ and lambda_b/ to sys.path so test files can import
-# validator, dispatcher, scanner, etc. without inline sys.path manipulation.
-# This file is loaded automatically by pytest before any test in this directory.
-
-import sys
-import os
-
-LAMBDA_A_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "lambda_a")
-LAMBDA_B_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "lambda_b")
-
-for path in (LAMBDA_A_DIR, LAMBDA_B_DIR):
-    abs_path = os.path.abspath(path)
-    if abs_path not in sys.path:
-        sys.path.insert(0, abs_path)
+# sys.path setup is handled by the parent tests/conftest.py which covers
+# all test suites (unit + integration). Nothing extra needed here.
 
 # test_lambda_a.py is a standalone script (no pytest test functions).
 # It replaces sys.modules["boto3"] with MagicMock at module level, which


### PR DESCRIPTION
Rebased clean version of PR #60 onto current main.

**Changes:**
- README.md: expand Local Development section with full quick-start, per-suite test instructions, env var tables, and project structure tree
- pytest.ini: testpaths=tests/unit tests/integration, --tb=short, scanner/e2e/load markers
- Makefile: install / test / test-unit / test-no-scan / test-integration / lint
- lambda_a/requirements.txt: add s3 to moto extras (moto[sqs,dynamodb,s3])
- lambda_b/requirements.txt: add pytest==8.0.0 and moto[dynamodb,sqs,s3] (were entirely missing)
- tests/conftest.py (new): move sys.path setup to tests/ root so integration tests can also import lambda modules
- tests/unit/conftest.py: remove duplicate path setup; preserve collect_ignore=[test_lambda_a.py] to prevent boto3 mock pollution

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)