### PR TITLE
fix: DLQ alarm uses DLQName export + mark scans FAILED on terminal error (closes #23)

### DIFF
--- a/sast-platform/infrastructure/cloudwatch.yaml
+++ b/sast-platform/infrastructure/cloudwatch.yaml
@@ -127,17 +127,13 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub "${ProjectName}-${Environment}-sqs-dlq-messages"
-      AlarmDescription: "SQS DLQ has messages — scans failing after 3 retries (see issue #23)"
+      AlarmDescription: "SQS DLQ has messages — scans failing after 3 retries"
       Namespace: AWS/SQS
       MetricName: ApproximateNumberOfMessagesVisible
       Dimensions:
         - Name: QueueName
-          Value: !Select
-            - 4
-            - !Split
-              - "/"
-              - !ImportValue
-                  Fn::Sub: "${SQSStackName}-DLQUrl"
+          Value: !ImportValue
+            Fn::Sub: "${SQSStackName}-DLQName"
       Statistic: Maximum
       Period: 60
       EvaluationPeriods: 1
@@ -377,12 +373,8 @@ Resources:
             Fn::Sub: "${ProjectName}-${Environment}-lambda-b-function-name"
           ScanQueueName: !ImportValue
             Fn::Sub: "${SQSStackName}-ScanQueueName"
-          DLQName: !Select
-            - 4
-            - !Split
-              - "/"
-              - !ImportValue
-                  Fn::Sub: "${SQSStackName}-DLQUrl"
+          DLQName: !ImportValue
+            Fn::Sub: "${SQSStackName}-DLQName"
           DynamoDBTableName: !ImportValue
             Fn::Sub: "${DynamoDBStackName}-ScanResultsTableName"
 

--- a/sast-platform/infrastructure/sqs.yaml
+++ b/sast-platform/infrastructure/sqs.yaml
@@ -148,3 +148,9 @@ Outputs:
     Value: !GetAtt ScanDeadLetterQueue.Arn
     Export:
       Name: !Sub "${AWS::StackName}-DLQArn"
+
+  DeadLetterQueueName:
+    Description: Physical name of the dead-letter queue (for CloudWatch alarm dimension)
+    Value: !GetAtt ScanDeadLetterQueue.QueueName
+    Export:
+      Name: !Sub "${AWS::StackName}-DLQName"

--- a/sast-platform/lambda_b/handler.py
+++ b/sast-platform/lambda_b/handler.py
@@ -72,6 +72,8 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
         
         for record in records:
             s3_code_key = None  # ensure cleanup is possible even if message parsing fails
+            scan_id     = None
+            student_id  = None
             try:
                 # Parse message
                 message_body = json.loads(record['body'])
@@ -112,6 +114,12 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                 # Clean up S3 upload if we got far enough to know the key but
                 # failed before process_scan_request could handle cleanup itself.
                 _delete_uploaded_code(s3_bucket_name, s3_code_key)
+                # Mark the scan FAILED in DynamoDB so it doesn't stay PENDING forever
+                if scan_id and student_id:
+                    try:
+                        update_scan_status(table, student_id, scan_id, 'FAILED', error_message=error_msg)
+                    except Exception as db_error:
+                        logger.error(f"Failed to update FAILED status - scan_id: {scan_id}, error: {str(db_error)}")
                 failed_messages.append({
                     'record_id': record.get('messageId', 'unknown'),
                     'error': error_msg


### PR DESCRIPTION
## Summary

- **sqs.yaml**: add DeadLetterQueueName output/export so CloudWatch can reference the queue by name without URL-splitting
- **cloudwatch.yaml**: replace !Select/!Split on DLQUrl with !ImportValue DLQName in both the ScanDLQAlarm dimension and the dashboard DLQName substitution
- **handler.py**: initialize scan_id/student_id = None before inner try so the outer except can write FAILED to DynamoDB when message parsing fails, preventing scans from staying stuck in PENDING indefinitely

## Test plan
- [ ] Deploy updated sqs + cloudwatch stacks; verify ScanDLQAlarm fires when a message lands in the DLQ
- [ ] Force a parse error (malformed SQS body); confirm DynamoDB record transitions to FAILED
- [ ] pytest tests/unit/ -v

Generated with Claude Code