### PR TITLE
fix: startup env var validation in Lambda A, B, and ECS handler (closes #22)

### DIFF
--- a/sast-platform/lambda_a/handler.py
+++ b/sast-platform/lambda_a/handler.py
@@ -22,7 +22,16 @@ from history    import get_scan_history
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
-# Environment variables — set these in the Lambda console or CloudFormation
+# ---------------------------------------------------------------------------
+# Startup environment variable validation
+# Raises RuntimeError at import time so Lambda reports Runtime.ImportModuleError
+# with the full list of missing vars — visible in CloudWatch immediately.
+# ---------------------------------------------------------------------------
+_REQUIRED_ENV = ["SQS_QUEUE_URL", "DYNAMODB_TABLE", "S3_BUCKET", "AUTH_TABLE"]
+_missing = [v for v in _REQUIRED_ENV if not os.environ.get(v)]
+if _missing:
+    raise RuntimeError(f"Missing required environment variables: {_missing}")
+
 SQS_QUEUE_URL  = os.environ["SQS_QUEUE_URL"]
 DYNAMODB_TABLE = os.environ["DYNAMODB_TABLE"]
 S3_BUCKET      = os.environ["S3_BUCKET"]

--- a/sast-platform/lambda_b/ecs_handler.py
+++ b/sast-platform/lambda_b/ecs_handler.py
@@ -16,6 +16,20 @@ from botocore.exceptions import ClientError
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger()
 
+# ---------------------------------------------------------------------------
+# Startup environment variable validation
+# Fails immediately on container start so ECS reports the error in task logs
+# before the scan is attempted, with the full list of missing variables.
+# ---------------------------------------------------------------------------
+_REQUIRED_ENV = [
+    "SCAN_ID", "STUDENT_ID", "LANGUAGE",
+    "DYNAMODB_TABLE_NAME", "S3_BUCKET_NAME",
+]
+_missing_env = [v for v in _REQUIRED_ENV if not os.environ.get(v)]
+if _missing_env:
+    logger.error("Missing required environment variables: %s", _missing_env)
+    sys.exit(1)
+
 # connect to DynamoDB and S3
 dynamodb = boto3.resource("dynamodb")
 s3_client = boto3.client("s3")
@@ -45,23 +59,11 @@ def _fetch_code(s3_bucket_name: str) -> str:
 
 def main():
     try:
-        # required info from env variables
-        scan_id    = os.environ.get("SCAN_ID")
-        student_id = os.environ.get("STUDENT_ID")
-        language   = os.environ.get("LANGUAGE")
-
-        missing = [name for name, val in [("SCAN_ID", scan_id), ("STUDENT_ID", student_id), ("LANGUAGE", language)] if not val]
-        if missing:
-            raise ValueError("Missing required environment variables: " + ", ".join(missing))
-
-        # get table and bucket names
-        table_name     = os.environ.get("DYNAMODB_TABLE_NAME")
-        s3_bucket_name = os.environ.get("S3_BUCKET_NAME")
-
-        if not table_name:
-            raise ValueError("DYNAMODB_TABLE_NAME is not set")
-        if not s3_bucket_name:
-            raise ValueError("S3_BUCKET_NAME is not set")
+        scan_id        = os.environ["SCAN_ID"]
+        student_id     = os.environ["STUDENT_ID"]
+        language       = os.environ["LANGUAGE"]
+        table_name     = os.environ["DYNAMODB_TABLE_NAME"]
+        s3_bucket_name = os.environ["S3_BUCKET_NAME"]
 
         logger.info(f"Start scan task: {scan_id}")
 

--- a/sast-platform/lambda_b/handler.py
+++ b/sast-platform/lambda_b/handler.py
@@ -20,6 +20,16 @@ _missing = [tool for tool in ("bandit", "semgrep") if not shutil.which(tool)]
 if _missing:
     raise RuntimeError(f"Required scanner binaries not found in PATH: {_missing}")
 
+# ---------------------------------------------------------------------------
+# Startup environment variable validation
+# Raises RuntimeError at import time so Lambda reports Runtime.ImportModuleError
+# with the full list of missing vars — visible in CloudWatch immediately.
+# ---------------------------------------------------------------------------
+_REQUIRED_ENV = ["DYNAMODB_TABLE_NAME", "S3_BUCKET_NAME"]
+_missing_env = [v for v in _REQUIRED_ENV if not os.environ.get(v)]
+if _missing_env:
+    raise RuntimeError(f"Missing required environment variables: {_missing_env}")
+
 from scanner import scan_code_with_timeout
 from result_parser import normalize_result
 from s3_writer import write_scan_result_to_s3, get_s3_bucket_from_env, S3WriteError


### PR DESCRIPTION
## Summary

- **lambda_a/handler.py**: validate SQS_QUEUE_URL, DYNAMODB_TABLE, S3_BUCKET, AUTH_TABLE at module load; raises RuntimeError with the full missing-var list so Lambda reports Runtime.ImportModuleError in CloudWatch immediately
- **lambda_b/handler.py**: same pattern for DYNAMODB_TABLE_NAME, S3_BUCKET_NAME
- **lambda_b/ecs_handler.py**: module-level check for SCAN_ID, STUDENT_ID, LANGUAGE, DYNAMODB_TABLE_NAME, S3_BUCKET_NAME; sys.exit(1) on failure so ECS task fails fast with a clear log message. CODE_CONTENT intentionally excluded — _fetch_code() handles the S3_CODE_KEY/CODE_CONTENT fallback. main() simplified to use os.environ[] directly.

## Fix vs PR #54
PR #54 listed CODE_CONTENT in the ECS required-env list, but current main uses S3_CODE_KEY (merged via #65). Corrected here.

## Test plan
- [ ] Deploy Lambda A/B with a missing env var; confirm CloudWatch shows Runtime.ImportModuleError with the full list
- [ ] pytest tests/unit/ -v

Generated with Claude Code