### PR TITLE
docs: demo fixtures, README fixes, and smoke test corrections

### DIFF
--- a/sast-platform/README.md
+++ b/sast-platform/README.md
@@ -33,7 +33,7 @@ Browser
                                                                   → presigned URL
 ```
 
-**Scan status lifecycle:** `PENDING` → `DONE` | `FAILED`
+**Scan status lifecycle:** `PENDING` → `IN_PROGRESS` → `DONE` | `FAILED`
 
 ---
 
@@ -86,7 +86,7 @@ python scripts/00_seed_auth.py --table StudentAuth --add-student zhang.jings
 
 **Base URL:** Lambda A Function URL (printed by `01_setup_infra.sh`)
 
-### POST / — Submit a scan
+### POST /scan — Submit a scan
 
 ```
 Headers:
@@ -108,16 +108,23 @@ Supported languages: python, java, javascript, typescript, go, ruby, c, cpp
 
 ---
 
-### GET /?scan_id=\<id\> — Poll scan status
+### GET /status?scan_id=\<id\> — Poll scan status
 
 ```
 Headers:
   X-Student-Key: <api_key>
 ```
 
-**Response 200 (PENDING):**
+**Response 200 (PENDING / IN_PROGRESS):**
 ```json
-{ "scan_id": "scan-a1b2c3d4", "status": "PENDING", "language": "python", "created_at": "..." }
+{
+  "scan_id": "scan-a1b2c3d4",
+  "status": "PENDING",
+  "language": "python",
+  "created_at": "...",
+  "retry_after_seconds": 5,
+  "scan_expires_at": "2025-01-01T13:00:00+00:00"
+}
 ```
 
 **Response 200 (DONE):**
@@ -128,11 +135,60 @@ Headers:
   "language": "python",
   "vuln_count": 3,
   "completed_at": "...",
-  "report_url": "https://s3.amazonaws.com/...?X-Amz-Expires=3600&..."
+  "report_url": "https://s3.amazonaws.com/...?X-Amz-Expires=3600&...",
+  "report_url_expires_at": "2025-01-01T13:00:00+00:00"
 }
 ```
 
 **Errors:** `400` missing scan_id · `401` auth · `403` not your scan · `404` not found
+
+---
+
+### GET /history — List past scans
+
+```
+Headers:
+  X-Student-Key: <api_key>
+```
+
+**Response 200:**
+```json
+{
+  "student_id": "neu123456",
+  "scans": [
+    { "scan_id": "scan-a1b2c3d4", "status": "DONE", "language": "python", "vuln_count": 3, "created_at": "...", "completed_at": "..." }
+  ]
+}
+```
+
+**Errors:** `401` auth
+
+---
+
+## Demo Fixtures
+
+`tests/fixtures/` contains sample files with known vulnerabilities for demo purposes.
+
+### `vulnerable_python.py`
+
+Submit with **language: python**. Triggers Bandit findings:
+
+| Rule | Severity | Description |
+|------|----------|-------------|
+| B602 | HIGH | `subprocess.call` with `shell=True` — command injection |
+| B307 | HIGH | `eval()` — arbitrary code execution |
+| B301 | MEDIUM | `pickle.loads` — arbitrary object deserialization |
+| B105 | LOW | Hardcoded password string |
+
+### `vulnerable_javascript.js`
+
+Submit with **language: javascript**. Triggers Semgrep findings:
+
+| Rule | Description |
+|------|-------------|
+| `javascript.lang.security.audit.eval-detected` | `eval()` with user-controlled input |
+| `javascript.sequelize.security.audit.sequelize-injection` | SQL injection via template literal |
+| `javascript.lang.security.audit.hardcoded-credentials` | Hardcoded DB password |
 
 ---
 

--- a/sast-platform/scripts/05_test_api.sh
+++ b/sast-platform/scripts/05_test_api.sh
@@ -74,7 +74,7 @@ PAYLOAD=$(jq -n --arg code "$TEST_CODE" --arg lang "python" \
   '{"code": $code, "language": $lang}')
 
 SUBMIT_RESP=$(curl -s -w "\n%{http_code}" \
-  -X POST "$LAMBDA_URL" \
+  -X POST "$LAMBDA_URL/scan" \
   -H "Content-Type: application/json" \
   -H "X-Student-Key: $STUDENT_KEY" \
   -d "$PAYLOAD")
@@ -97,7 +97,7 @@ log "Polling for results (timeout: ${POLL_TIMEOUT}s)..."
 DEADLINE=$(( $(date +%s) + POLL_TIMEOUT ))
 STATUS="PENDING"
 
-while [[ "$STATUS" == "PENDING" ]]; do
+while [[ "$STATUS" == "PENDING" || "$STATUS" == "IN_PROGRESS" ]]; do
   if [[ $(date +%s) -gt $DEADLINE ]]; then
     fail "Timed out waiting for scan to complete (>${POLL_TIMEOUT}s)"
   fi
@@ -105,7 +105,7 @@ while [[ "$STATUS" == "PENDING" ]]; do
   sleep "$POLL_INTERVAL"
 
   STATUS_RESP=$(curl -s -w "\n%{http_code}" \
-    "$LAMBDA_URL?scan_id=$SCAN_ID" \
+    "$LAMBDA_URL/status?scan_id=$SCAN_ID" \
     -H "X-Student-Key: $STUDENT_KEY")
 
   HTTP_STATUS=$(echo "$STATUS_RESP" | tail -1)

--- a/sast-platform/tests/fixtures/vulnerable_javascript.js
+++ b/sast-platform/tests/fixtures/vulnerable_javascript.js
@@ -1,0 +1,33 @@
+// vulnerable_javascript.js — sample file for SAST Platform demo
+//
+// Submit this file via the UI (language: javascript) to produce known findings.
+// Expected Semgrep results:
+//   javascript.lang.security.audit.eval-detected        — eval injection
+//   javascript.sequelize.security.audit.sequelize-injection — SQL injection via template literal
+//   javascript.lang.security.audit.hardcoded-credentials — hardcoded secret
+
+const express = require('express');
+const { Sequelize } = require('sequelize');
+
+const DB_PASSWORD = 'supersecret123';   // hardcoded credential
+
+const app = express();
+const sequelize = new Sequelize(`postgres://admin:${DB_PASSWORD}@localhost/mydb`);
+
+// SQL injection via template literal — user input embedded directly in query
+app.get('/user', async (req, res) => {
+    const userId = req.query.id;
+    const result = await sequelize.query(
+        `SELECT * FROM users WHERE id = ${userId}`   // injection: userId not sanitized
+    );
+    res.json(result);
+});
+
+// eval injection — user-controlled code executed directly
+app.get('/calc', (req, res) => {
+    const expression = req.query.expr;
+    const answer = eval(expression);    // arbitrary code execution
+    res.send(`Result: ${answer}`);
+});
+
+app.listen(3000);

--- a/sast-platform/tests/fixtures/vulnerable_python.py
+++ b/sast-platform/tests/fixtures/vulnerable_python.py
@@ -1,0 +1,38 @@
+# vulnerable_python.py — sample file for SAST Platform demo
+#
+# Submit this file via the UI (language: python) to produce known HIGH findings.
+# Expected Bandit results:
+#   B602 HIGH   — subprocess call with shell=True (command injection)
+#   B307 HIGH   — use of eval
+#   B301 MEDIUM — use of pickle.loads
+#   B105 LOW    — hardcoded password string
+
+import subprocess
+import pickle
+import os
+
+ADMIN_PASSWORD = "hunter2"          # B105: hardcoded password
+
+
+def run_command(user_input):
+    # B602: subprocess with shell=True — arbitrary command injection
+    subprocess.call(user_input, shell=True)
+
+
+def evaluate_expression(user_input):
+    # B307: eval — arbitrary code execution
+    return eval(user_input)
+
+
+def load_data(user_bytes):
+    # B301: pickle.loads — arbitrary object deserialization
+    return pickle.loads(user_bytes)
+
+
+if __name__ == "__main__":
+    cmd = input("Enter command: ")
+    run_command(cmd)
+
+    expr = input("Enter expression: ")
+    result = evaluate_expression(expr)
+    print("Result:", result)


### PR DESCRIPTION
## Summary

- **`tests/fixtures/vulnerable_python.py`** — new sample file with 4 known Bandit findings (B602 HIGH command injection, B307 HIGH eval, B301 MEDIUM pickle, B105 LOW hardcoded password); submit via UI with language `python` for a predictable demo
- **`tests/fixtures/vulnerable_javascript.js`** — new sample file with 3 known Semgrep findings (eval injection, SQL injection via template literal, hardcoded credential); submit with language `javascript`
- **`scripts/05_test_api.sh`** — fix 2 bugs: POST was hitting `$LAMBDA_URL` (missing `/scan` suffix) and GET was hitting `$LAMBDA_URL?scan_id=...` (missing `/status` path); polling loop only checked `PENDING` — extended to also loop on `IN_PROGRESS`
- **`README.md`** — fix 3 inaccurate API paths (`POST /` → `POST /scan`, `GET /` → `GET /status`); update scan status lifecycle to `PENDING → IN_PROGRESS → DONE | FAILED`; add `retry_after_seconds`/`scan_expires_at` to PENDING response docs and `report_url_expires_at` to DONE; add `GET /history` endpoint; add Demo Fixtures section

## Test plan

- [ ] Submit `vulnerable_python.py` via UI — should produce ≥ 3 HIGH findings
- [ ] Submit `vulnerable_javascript.js` via UI — should produce findings including eval and SQL injection
- [ ] Run `./scripts/05_test_api.sh --url <LAMBDA_URL> --key <KEY>` — should submit, poll through IN_PROGRESS, and print vuln count > 0
- [ ] README renders correctly on GitHub

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)