### PR TITLE
fix: define S3WriteError in s3_writer and add missing student_id in ECS

### DIFF
--- a/sast-platform/lambda_b/ecs_handler.py
+++ b/sast-platform/lambda_b/ecs_handler.py
@@ -137,6 +137,7 @@ def process_ecs_scan(scan_id, code, language, student_id, table, s3_bucket_name,
         s3_key, _ = write_scan_result_to_s3(
             bucket_name=s3_bucket_name,
             scan_id=scan_id,
+            student_id=student_id,
             report_data=parsed_result
         )
 

--- a/sast-platform/lambda_b/s3_writer.py
+++ b/sast-platform/lambda_b/s3_writer.py
@@ -8,6 +8,10 @@ from botocore.exceptions import ClientError, NoCredentialsError
 logger = logging.getLogger(__name__)
 
 
+class S3WriteError(Exception):
+    """Raised when writing a scan report to S3 fails."""
+
+
 class S3Writer:
     """Save scan reports to S3."""
 
@@ -44,16 +48,16 @@ class S3Writer:
 
         except NoCredentialsError:
             logger.error("AWS credentials were not found")
-            raise Exception("AWS credentials were not found")
+            raise S3WriteError("AWS credentials were not found")
 
         except ClientError as e:
             error_msg = e.response["Error"]["Message"]
             logger.error(f"failed to upload report: {error_msg}")
-            raise Exception(f"failed to upload report: {error_msg}")
+            raise S3WriteError(f"failed to upload report: {error_msg}")
 
         except Exception as e:
             logger.error(f"unexpected error: {str(e)}")
-            raise Exception(f"unexpected error: {str(e)}")
+            raise S3WriteError(f"unexpected error: {str(e)}")
 
     def generate_presigned_url(self, s3_key, expiration=3600):
         """Create a temporary download link."""

--- a/sast-platform/lambda_b/s3_writer.py
+++ b/sast-platform/lambda_b/s3_writer.py
@@ -74,11 +74,11 @@ class S3Writer:
         except ClientError as e:
             error_msg = e.response["Error"]["Message"]
             logger.error(f"failed to generate URL: {error_msg}")
-            raise Exception(f"failed to generate URL: {error_msg}")
+            raise S3WriteError(f"failed to generate URL: {error_msg}")
 
         except Exception as e:
             logger.error(f"unexpected error: {str(e)}")
-            raise Exception(f"unexpected error: {str(e)}")
+            raise S3WriteError(f"unexpected error: {str(e)}")
 
     def check_object_exists(self, s3_key):
         """Check if a report exists in S3."""


### PR DESCRIPTION
## Summary

Two runtime bugs found during code review that would crash the system in production.

### Bug 1 — `S3WriteError` not defined in `s3_writer.py` (Critical)

`handler.py` and `ecs_handler.py` both import `S3WriteError` from `s3_writer`:
```python
from s3_writer import write_scan_result_to_s3, get_s3_bucket_from_env, S3WriteError
```
But `S3WriteError` was never defined in `s3_writer.py` — only a generic `S3Writer` class existed.

**Impact**: `ImportError` at Lambda B cold start and ECS container startup. Neither could process any scan.

**Fix**: Added `class S3WriteError(Exception)` to `s3_writer.py` and changed `write_scan_report()` to raise it instead of bare `Exception`, so callers can catch it specifically.

### Bug 2 — Missing `student_id` in `ecs_handler.py` S3 write call (Critical)

`write_scan_result_to_s3()` requires `student_id` as a positional argument (used to build the S3 path `reports/{student_id}/{scan_id}.json`), but `ecs_handler.py` called it without `student_id`:
```python
# Before (broken)
s3_key, _ = write_scan_result_to_s3(bucket_name=..., scan_id=..., report_data=...)

# After (fixed)
s3_key, _ = write_scan_result_to_s3(bucket_name=..., scan_id=..., student_id=student_id, report_data=...)
```

**Impact**: `TypeError` on every ECS Fargate scan (large file path >250KB). All large submissions would fail after scanning, losing the result.

## Test plan
- [ ] Lambda B cold start succeeds (no ImportError)
- [ ] ECS scan completes and report appears under `reports/{student_id}/{scan_id}.json` in S3
- [ ] Lambda B scan path still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)