### PR TITLE
fix: define S3WriteError in s3_writer.py (closes #76)

### DIFF
--- a/sast-platform/lambda_b/s3_writer.py
+++ b/sast-platform/lambda_b/s3_writer.py
@@ -8,6 +8,11 @@ from botocore.exceptions import ClientError, NoCredentialsError
 logger = logging.getLogger(__name__)
 
 
+class S3WriteError(Exception):
+    """Raised when a scan report cannot be written to or read from S3."""
+    pass
+
+
 class S3Writer:
     """Save scan reports to S3."""
 
@@ -44,16 +49,16 @@ class S3Writer:
 
         except NoCredentialsError:
             logger.error("AWS credentials were not found")
-            raise Exception("AWS credentials were not found")
+            raise S3WriteError("AWS credentials were not found")
 
         except ClientError as e:
             error_msg = e.response["Error"]["Message"]
             logger.error(f"failed to upload report: {error_msg}")
-            raise Exception(f"failed to upload report: {error_msg}")
+            raise S3WriteError(f"failed to upload report: {error_msg}")
 
         except Exception as e:
             logger.error(f"unexpected error: {str(e)}")
-            raise Exception(f"unexpected error: {str(e)}")
+            raise S3WriteError(f"unexpected error writing report: {str(e)}")
 
     def generate_presigned_url(self, s3_key, expiration=3600):
         """Create a temporary download link."""
@@ -70,11 +75,11 @@ class S3Writer:
         except ClientError as e:
             error_msg = e.response["Error"]["Message"]
             logger.error(f"failed to generate URL: {error_msg}")
-            raise Exception(f"failed to generate URL: {error_msg}")
+            raise S3WriteError(f"failed to generate URL: {error_msg}")
 
         except Exception as e:
             logger.error(f"unexpected error: {str(e)}")
-            raise Exception(f"unexpected error: {str(e)}")
+            raise S3WriteError(f"unexpected error generating URL: {str(e)}")
 
     def check_object_exists(self, s3_key):
         """Check if a report exists in S3."""


### PR DESCRIPTION
## Problem

`handler.py` and `ecs_handler.py` both import `S3WriteError` from `s3_writer`, but the class was never defined — causing `ImportError` at Lambda/ECS container startup before any scan could run.

Secondary issue: `write_scan_report` and `generate_presigned_url` were raising bare `Exception`, making the `except S3WriteError` blocks in `handler.py` and `ecs_handler.py` dead code. S3 failures would fall through to the generic `except Exception` handler instead.

## Fix

- Add `class S3WriteError(Exception): pass` to `s3_writer.py`
- Change all `raise Exception(...)` in `write_scan_report` and `generate_presigned_url` to `raise S3WriteError(...)`

## Test plan
- [ ] `pytest tests/unit/ -v` passes
- [ ] Verify `from s3_writer import S3WriteError` no longer raises ImportError

Closes #76