### PR TITLE
fix: raise SQS VisibilityTimeout default to 900s to match Lambda B timeout

### DIFF
--- a/sast-platform/infrastructure/sqs.yaml
+++ b/sast-platform/infrastructure/sqs.yaml
@@ -24,7 +24,7 @@ Parameters:
 
   VisibilityTimeoutSeconds:
     Type: Number
-    Default: 300          # 5 minutes — must be >= Lambda B / ECS task timeout
+    Default: 900          # 15 minutes — must be >= Lambda B timeout (900s)
     Description: >
       Time a message is invisible after being received.
       Set this >= the maximum scan duration so that a crashed consumer


### PR DESCRIPTION
## Summary

Fixes #78.

`sqs.yaml` had `VisibilityTimeoutSeconds` defaulting to `300` (5 min), but Lambda B's timeout is `900` (15 min). The comment in the file even stated the requirement correctly — the value just contradicted it.

## The problem

When a scan takes more than 5 minutes, SQS re-delivers the message while the first Lambda B invocation is still running. A second Lambda B instance picks it up and starts a duplicate scan. The idempotency guard (PENDING → IN_PROGRESS atomic claim) prevents double-completion, but the redundant invocation wastes CPU and can interfere with ECS routing logic.

## The fix

```yaml
# Before
Default: 300   # 5 minutes — must be >= Lambda B / ECS task timeout

# After  
Default: 900   # 15 minutes — must be >= Lambda B timeout (900s)
```

One-line change. No code changes, no test changes needed.

## Test plan
- [ ] Deploy updated `sqs.yaml` — confirm queue `VisibilityTimeout` is 900s in AWS console
- [ ] Submit a scan that takes >5 min — confirm no duplicate Lambda B invocation in CloudWatch logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)