### PR TITLE
fix: filter empty strings from ECS subnets/security groups split (closes #79)

### DIFF
--- a/sast-platform/lambda_b/handler.py
+++ b/sast-platform/lambda_b/handler.py
@@ -407,8 +407,8 @@ def handle_ecs_fallback(scan_id: str, language: str, student_id: str,
             launchType='FARGATE',
             networkConfiguration={
                 'awsvpcConfiguration': {
-                    'subnets':          os.environ.get('ECS_SUBNETS', '').split(','),
-                    'securityGroups':   os.environ.get('ECS_SECURITY_GROUPS', '').split(','),
+                    'subnets':          [s for s in os.environ.get('ECS_SUBNETS', '').split(',') if s],
+                    'securityGroups':   [s for s in os.environ.get('ECS_SECURITY_GROUPS', '').split(',') if s],
                     'assignPublicIp':   'ENABLED',
                 }
             },


### PR DESCRIPTION
## Problem

`''.split(',')` returns `['']` (a list with one empty string), not `[]`.

When `ECS_SUBNETS` or `ECS_SECURITY_GROUPS` env vars are empty (the default when ECS is not configured), `handle_ecs_fallback()` passed `subnets=['']` and `securityGroups=['']` to `ecs_client.run_task()`, causing an `InvalidParameterException` from the ECS API. The ECS fallback path for large submissions (>250 KB) was completely broken.

## Fix

```python
# Before
os.environ.get('ECS_SUBNETS', '').split(',')   # -> [''] when unset

# After
[s for s in os.environ.get('ECS_SUBNETS', '').split(',') if s]  # -> [] when unset
```

## Test plan
- [ ] `pytest tests/unit/ -v` passes
- [ ] Verify `handle_ecs_fallback` with empty env vars no longer passes empty-string subnet IDs to ECS

Closes #79