### PR TITLE
fix: replace deprecated datetime.utcnow() with datetime.now(timezone.utc) in Lambda B (closes #81)

### DIFF
--- a/sast-platform/lambda_b/ecs_handler.py
+++ b/sast-platform/lambda_b/ecs_handler.py
@@ -197,14 +197,14 @@ def process_ecs_scan(scan_id, code, language, student_id, table, s3_bucket_name,
 
 def update_scan_status_ecs(table, student_id, scan_id, status, vuln_count=0, s3_report_key=None, error_message=None):
     try:
-        from datetime import datetime
+        from datetime import datetime, timezone
 
         # base update fields
         update_expression = "SET #status = :status, completed_at = :completed_at, processing_method = :method"
         expression_attribute_names = {"#status": "status"}
         expression_attribute_values = {
             ":status": status,
-            ":completed_at": datetime.utcnow().isoformat() + "Z",
+            ":completed_at": datetime.now(timezone.utc).isoformat(),
             ":method": "ECS_FARGATE"
         }
 

--- a/sast-platform/lambda_b/handler.py
+++ b/sast-platform/lambda_b/handler.py
@@ -328,14 +328,14 @@ def update_scan_status(table: Any, student_id: str, scan_id: str, status: str,
         error_message: Error message (only used in FAILED status)
     """
     try:
-        from datetime import datetime
-        
+        from datetime import datetime, timezone
+
         # Build update expression
         update_expression = "SET #status = :status, completed_at = :completed_at"
         expression_attribute_names = {"#status": "status"}
         expression_attribute_values = {
             ":status": status,
-            ":completed_at": datetime.utcnow().isoformat() + 'Z'
+            ":completed_at": datetime.now(timezone.utc).isoformat()
         }
         
         if status == 'DONE':


### PR DESCRIPTION
## Problem

`lambda_b/handler.py` and `lambda_b/ecs_handler.py` both used `datetime.utcnow()` which:
- Is deprecated since Python 3.12
- Returns a naive datetime (no tzinfo), so the manually appended `'Z'` produces an inconsistent format vs Lambda A's `datetime.now(timezone.utc).isoformat()` which outputs `+00:00`

## Fix

Added `timezone` to the `datetime` import in both functions and replaced:
```python
# Before
datetime.utcnow().isoformat() + 'Z'   # -> '2026-04-02T15:30:45Z' (naive)

# After
datetime.now(timezone.utc).isoformat() # -> '2026-04-02T15:30:45+00:00' (aware)
```

All timestamps in DynamoDB now use the same format as Lambda A.

## Test plan
- [ ] `pytest tests/unit/ -v` passes

Closes #81