### PR TITLE
fix: align CloudFormation parameter defaults across stacks (closes #82)

### DIFF
--- a/sast-platform/infrastructure/lambda_a.yaml
+++ b/sast-platform/infrastructure/lambda_a.yaml
@@ -20,12 +20,12 @@ Parameters:
 
   DynamoDBTableName:
     Type: String
-    Default: sast-scans
+    Default: ScanResults
     Description: DynamoDB table name (must match dynamodb.yaml stack).
 
   S3ReportBucket:
     Type: String
-    Default: sast-reports
+    Default: sast-platform-reports
     Description: S3 bucket where scan reports are stored (used for presigned URLs).
 
   SQSStackName:

--- a/sast-platform/infrastructure/lambda_b.yaml
+++ b/sast-platform/infrastructure/lambda_b.yaml
@@ -20,7 +20,7 @@ Parameters:
   DynamoDBTableName:
     Type: String
     Description: 'DynamoDB table name for scan status'
-    Default: 'sast-scans'
+    Default: 'ScanResults'
   
   S3BucketName:
     Type: String


### PR DESCRIPTION
## Problem

`lambda_a.yaml` and `lambda_b.yaml` had stale default values that didn't match what `dynamodb.yaml`/`s3.yaml` actually create, nor what `01_setup_infra.sh` passes:

| Stack | Parameter | Old Default | Correct Value |
|-------|-----------|-------------|---------------|
| `lambda_a.yaml` | `DynamoDBTableName` | `sast-scans` | `ScanResults` |
| `lambda_a.yaml` | `S3ReportBucket` | `sast-reports` | `sast-platform-reports` |
| `lambda_b.yaml` | `DynamoDBTableName` | `sast-scans` | `ScanResults` |

Deploying any Lambda stack manually (outside of `01_setup_infra.sh`) with defaults would point Lambda A/B at a DynamoDB table and S3 bucket that don't exist, causing every scan to fail. `01_setup_infra.sh` always passes explicit values so deployed environments were unaffected.

## Fix

Updated the three defaults to match `dynamodb.yaml` (`ScanResults`) and `s3.yaml` (`sast-platform-reports`).

## Test plan
- [ ] `pytest tests/unit/ -v` passes
- [ ] Deploy lambda_a stack standalone with no parameter overrides — verify it targets the correct table and bucket

Closes #82