### PR TITLE
fix: skip rate-limit records in GET /history to avoid KeyError (closes #89)

### DIFF
--- a/sast-platform/lambda_a/history.py
+++ b/sast-platform/lambda_a/history.py
@@ -44,7 +44,13 @@ def get_scan_history(student_id: str, table_name: str) -> list:
         KeyConditionExpression=Key("student_id").eq(student_id),
         Limit=MAX_HISTORY_ITEMS,
     )
-    items = response.get("Items", [])
+    # Filter out synthetic rate-limit records (scan_id starts with "rate#")
+    # before formatting — they have no "status"/"language"/"created_at" fields
+    # and cause a KeyError in _format_item().
+    items = [
+        i for i in response.get("Items", [])
+        if not i.get("scan_id", "").startswith("rate#")
+    ]
 
     # scan_id is not time-ordered, so sort by created_at in Python
     items.sort(key=lambda x: x.get("created_at", ""), reverse=True)


### PR DESCRIPTION
## Summary

- Filters out synthetic rate-limit records (scan_id starts with rate#) from DynamoDB results before passing to _format_item()
- Rate-limit records have no status/language/created_at fields; _format_item() does item["status"] unconditionally, causing KeyError -> 500

## Fix

Added a filter between the DynamoDB response and the sort+format step in get_scan_history():

```python
items = [
    i for i in response.get("Items", [])
    if not i.get("scan_id", "").startswith("rate#")
]
```

Using client-side filtering rather than FilterExpression because FilterExpression is applied after DynamoDB's Limit — using it would under-return real scan records when students have many rate-limit entries.

## Test plan
- [ ] Student with active rate-limit record: GET /history returns 200 with only real scan records
- [ ] Student with no scans: GET /history returns 200 with empty list
- [ ] Student with 50+ scans: newest 50 returned, no rate-limit records included

Generated with [Claude Code](https://claude.com/claude-code)