### PR TITLE
feat: single-command deploy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,48 @@
 # SAST Platform — Student Assignment Security Checker
 
-**CS6620 Group 9** | Jingsi Zhang · Mengshan Li · Jiahua Wu
+**CS6620 Group 9** | Jingsi (Jess) Zhang · Mengshan (Sunny) Li · Jiahua (Liz) Wu
 
 A serverless static analysis platform on AWS. Students submit source code via a web UI; the system scans it asynchronously using Bandit (Python) and Semgrep (Java / JavaScript / TypeScript / Go / Ruby / C / C++), stores the report in S3, and returns a presigned download URL to the browser.
+
+---
+
+## Quick Start
+
+**Deploy the full platform in one command:**
+
+```bash
+# 1. Clone the repo
+git clone https://github.com/sunnythreethree/Student-Assignment-Security-Checking-Platform.git
+cd Student-Assignment-Security-Checking-Platform/sast-platform
+
+# 2. Create an S3 bucket for Lambda deployment packages (one-time)
+aws s3 mb s3://my-sast-deploy-bucket --region us-east-1
+
+# 3. Deploy everything
+./scripts/deploy.sh --code-bucket my-sast-deploy-bucket
+
+# 4. Seed an API key for a student
+python scripts/00_seed_auth.py --table StudentAuth --add-student zhang.jings
+
+# 5. Open the frontend URL printed at the end of step 3
+```
+
+That's it. The script provisions all AWS infrastructure, packages and deploys both Lambda functions, uploads the frontend, and optionally runs a smoke test.
+
+> **With ECS Fargate fallback + smoke test:**
+> ```bash
+> ./scripts/deploy.sh \
+>   --code-bucket my-sast-deploy-bucket \
+>   --vpc-id vpc-xxxxxxxx \
+>   --subnets subnet-aaa,subnet-bbb \
+>   --student-key <api-key-from-step-4>
+> ```
+
+> **Via Make:**
+> ```bash
+> make deploy CODE_BUCKET=my-sast-deploy-bucket
+> make deploy CODE_BUCKET=my-sast-deploy-bucket VPC_ID=vpc-xxx SUBNETS=subnet-aaa STUDENT_KEY=abc123
+> ```
 
 ---
 
@@ -40,6 +80,181 @@ Browser
 
 ---
 
+## Prerequisites
+
+| Tool | Version | Required for |
+|------|---------|-------------|
+| AWS CLI | any | All deployment |
+| AWS credentials | configured | All deployment (`aws configure` or IAM role) |
+| Python | 3.12+ | Lambda code + tests |
+| `jq` | any | Smoke test (`05_test_api.sh`) |
+| Docker | any | ECS image build only (optional) |
+
+Install on macOS:
+```bash
+brew install awscli python jq
+```
+
+Install on Ubuntu/Debian:
+```bash
+sudo apt install awscli python3 jq
+```
+
+Configure AWS credentials:
+```bash
+aws configure          # enter Access Key ID, Secret, region, output format
+aws sts get-caller-identity   # verify — should print your account ID
+```
+
+---
+
+## Deployment
+
+### Option A — Single command (recommended)
+
+```bash
+cd sast-platform
+./scripts/deploy.sh --code-bucket <your-s3-bucket> [OPTIONS]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--code-bucket` | *(required)* | S3 bucket for Lambda zip uploads |
+| `--env` | `dev` | Environment tag applied to all stacks |
+| `--region` | `us-east-1` | AWS region |
+| `--vpc-id` | — | Enable ECS Fargate fallback (requires `--subnets`) |
+| `--subnets` | — | Comma-separated subnet IDs for ECS tasks |
+| `--scanner-image` | auto | ECR image URI override for ECS scanner |
+| `--student-key` | — | Run end-to-end smoke test with this API key |
+| `--skip-ecs` | — | Skip ECS image build even when `--vpc-id` is set |
+| `--skip-test` | — | Skip smoke test unconditionally |
+
+**What it runs internally:**
+
+| Step | Script | What it does |
+|------|--------|-------------|
+| 1 | `01_setup_infra.sh` | Deploy all CloudFormation stacks |
+| 2 | `02_deploy_lambda_a.sh` | Package and deploy Lambda A |
+| 3 | `03_deploy_lambda_b.sh` | Package and deploy Lambda B |
+| 4 | `04_build_ecs_image.sh` | Build + push ECS scanner image *(only with `--vpc-id`)* |
+| 5 | `04_upload_frontend.sh` | Inject Lambda URL, sync frontend to S3 |
+| 6 | `05_test_api.sh` | End-to-end smoke test *(only with `--student-key`)* |
+
+### Option B — Step by step
+
+Run from `sast-platform/scripts/` if you need to deploy or redeploy individual components:
+
+```bash
+cd sast-platform/scripts
+
+# 1. CloudFormation stacks (S3, DynamoDB, SQS, Lambda A/B, CloudWatch)
+./01_setup_infra.sh --code-bucket <bucket> --env dev
+
+# 2. Lambda A code
+./02_deploy_lambda_a.sh --code-bucket <bucket>
+
+# 3. Lambda B code
+./03_deploy_lambda_b.sh   # reads CODE_BUCKET env var
+
+# 4a. (Optional) ECS scanner image
+./04_build_ecs_image.sh
+
+# 4b. Frontend
+./04_upload_frontend.sh
+
+# 5. Smoke test
+LAMBDA_URL=<url> STUDENT_KEY=<key> ./05_test_api.sh
+```
+
+### Seed API keys
+
+Students need an API key to authenticate. Generate keys after deploying infrastructure:
+
+```bash
+# Add a single student
+python scripts/00_seed_auth.py --table StudentAuth --add-student zhang.jings
+
+# Bulk-add from a file (one student ID per line)
+python scripts/00_seed_auth.py --table StudentAuth --students students.txt
+```
+
+The generated key is printed to stdout — share it with the student securely.
+
+---
+
+## Using the Platform
+
+### As a student
+
+1. **Open the frontend** — use the URL printed at the end of deployment (or find it in the CloudFormation output for `sast-platform-s3` → `FrontendWebsiteURL`).
+
+2. **Enter your Student ID and API key** in the login form.
+
+3. **Paste or upload your source code**, select the language, and click **Scan**.
+
+4. **Wait for results** — the page polls automatically. When the scan is `DONE`, a download button appears for the JSON vulnerability report.
+
+5. **View scan history** — the History tab shows your last 50 scans.
+
+### Supported languages
+
+`python` · `java` · `javascript` · `typescript` · `go` · `ruby` · `c` · `cpp`
+
+### Via the API directly
+
+```bash
+LAMBDA_URL=https://<your-function-url>
+STUDENT_KEY=<your-api-key>
+
+# Submit a scan
+curl -X POST "$LAMBDA_URL/scan" \
+  -H "Content-Type: application/json" \
+  -H "X-Student-Key: $STUDENT_KEY" \
+  -d '{"code": "import os\nos.system(input())", "language": "python"}'
+# → {"scan_id": "scan-a1b2c3d4", "status": "PENDING", ...}
+
+# Poll for results
+curl "$LAMBDA_URL/status?scan_id=scan-a1b2c3d4" \
+  -H "X-Student-Key: $STUDENT_KEY"
+# → {"status": "DONE", "vuln_count": 1, "report_url": "https://..."}
+
+# View history
+curl "$LAMBDA_URL/history" \
+  -H "X-Student-Key: $STUDENT_KEY"
+```
+
+Rate limit: **10 scans per hour per student**.
+
+---
+
+## Running Tests Locally
+
+No AWS account needed — all AWS calls are mocked by [moto](https://github.com/getmoto/moto).
+
+```bash
+cd sast-platform
+
+# Install deps
+pip install -r lambda_a/requirements.txt -r lambda_b/requirements.txt
+
+# Run all unit tests
+pytest tests/unit -v
+
+# Skip scanner tests if bandit/semgrep are not installed locally
+pytest tests/unit -v -k "not scanner"
+```
+
+Or via Make:
+
+```bash
+make install        # install deps for both lambdas
+make test-unit      # unit tests only
+make test-no-scan   # skip scanner (no bandit/semgrep needed)
+make test           # unit + integration
+```
+
+---
+
 ## Repository Layout
 
 ```
@@ -62,7 +277,15 @@ sast-platform/
 │   └── requirements.txt
 ├── frontend/               # Static HTML + CSS + JS
 ├── infrastructure/         # CloudFormation templates (S3, DynamoDB, SQS, Lambda, ECS, CloudWatch)
-├── scripts/                # Sequential deploy scripts (00–05)
+├── scripts/
+│   ├── deploy.sh           # Single-command full-stack deploy (wraps 01–05)
+│   ├── 00_seed_auth.py     # Seed student API keys into DynamoDB
+│   ├── 01_setup_infra.sh   # Deploy CloudFormation stacks
+│   ├── 02_deploy_lambda_a.sh
+│   ├── 03_deploy_lambda_b.sh
+│   ├── 04_build_ecs_image.sh
+│   ├── 04_upload_frontend.sh
+│   └── 05_test_api.sh      # End-to-end smoke test
 ├── tests/
 │   ├── unit/               # Fast, moto-backed — no AWS required
 │   ├── integration/        # Service-level, moto-backed
@@ -75,88 +298,11 @@ sast-platform/
 
 ---
 
-## Prerequisites
-
-| Tool | Required for |
-|------|-------------|
-| AWS CLI (configured) | All deployment scripts |
-| Python 3.12+ | Lambda code + tests |
-| `jq` | `05_test_api.sh` smoke test |
-| Docker | ECS image build only |
-
----
-
-## Deployment
-
-Run all scripts from `sast-platform/scripts/`:
-
-```bash
-cd sast-platform/scripts
-
-# 1. Deploy CloudFormation stacks (S3, DynamoDB, SQS, Lambda A/B, CloudWatch)
-./01_setup_infra.sh --code-bucket <your-deploy-bucket> --env dev
-
-# 2. Deploy Lambda A
-./02_deploy_lambda_a.sh
-
-# 3. Deploy Lambda B
-./03_deploy_lambda_b.sh
-
-# 4a. (Optional) Build + push ECS scanner image
-./04_build_ecs_image.sh
-
-# 4b. Upload frontend to S3
-./04_upload_frontend.sh
-
-# 5. Smoke test — verifies the live API end-to-end
-LAMBDA_URL=<from step 1 output> STUDENT_KEY=<from seed script> ./05_test_api.sh
-```
-
-### Seed API keys
-
-```bash
-# Add a single student
-python scripts/00_seed_auth.py --table StudentAuth --add-student zhang.jings
-
-# Bulk-add from file
-python scripts/00_seed_auth.py --table StudentAuth --students students.txt
-```
-
----
-
-## Running Tests Locally
-
-No AWS account needed — all AWS calls are mocked by [moto](https://github.com/getmoto/moto).
-
-```bash
-cd sast-platform
-
-# Install deps
-pip install -r lambda_a/requirements.txt -r lambda_b/requirements.txt
-
-# Run all unit tests
-pytest tests/unit -v
-
-# Skip scanner tests if bandit/semgrep are not installed
-pytest tests/unit -v -k "not scanner"
-```
-
-Or via Make:
-
-```bash
-make install        # install deps for both lambdas
-make test-unit      # unit tests only
-make test-no-scan   # skip scanner (no bandit/semgrep needed)
-make test           # unit + integration
-```
-
----
-
 ## API Reference
 
 **Authentication:** all endpoints require `X-Student-Key: <api_key>` header.
 
-**Base URL:** Lambda A Function URL (printed by `01_setup_infra.sh`).
+**Base URL:** Lambda A Function URL (printed by `deploy.sh` or `01_setup_infra.sh`).
 
 ### `POST /scan`
 
@@ -246,7 +392,11 @@ Returns the 50 most recent scans for the authenticated student.
 | `vulnerable_python.py` | python | B602 HIGH (shell injection), B307 HIGH (eval), B301 MEDIUM (pickle), B105 LOW (hardcoded password) |
 | `vulnerable_javascript.js` | javascript | eval injection, SQL injection (template literal), hardcoded credential |
 
-Submit either file through the UI or via the smoke test script.
+Submit either file through the UI or run the smoke test:
+
+```bash
+LAMBDA_URL=<url> STUDENT_KEY=<key> ./scripts/05_test_api.sh
+```
 
 ---
 

--- a/sast-platform/Makefile
+++ b/sast-platform/Makefile
@@ -1,11 +1,15 @@
 # Makefile — convenience targets for local development
 # Run from the sast-platform/ directory.
 
-.PHONY: install install-a install-b test test-unit test-no-scan test-integration lint help
+.PHONY: install install-a install-b test test-unit test-no-scan test-integration lint deploy help
 
 help:
 	@echo "Usage: make <target>"
 	@echo ""
+	@echo "  deploy         Full-stack deploy (requires CODE_BUCKET)"
+	@echo "                 make deploy CODE_BUCKET=my-bucket [ENV=dev] [REGION=us-east-1]"
+	@echo "                 make deploy CODE_BUCKET=my-bucket VPC_ID=vpc-xxx SUBNETS=subnet-xxx"
+	@echo "                 make deploy CODE_BUCKET=my-bucket STUDENT_KEY=abc123  (+ smoke test)"
 	@echo "  install        Install test deps for both Lambda A and B"
 	@echo "  install-a      Install Lambda A deps only"
 	@echo "  install-b      Install Lambda B deps only"
@@ -14,6 +18,18 @@ help:
 	@echo "  test-no-scan   Run unit tests, skip scanner (no bandit/semgrep needed)"
 	@echo "  test-integration  Run integration tests only"
 	@echo "  lint           Run bandit on lambda_a/ and lambda_b/"
+
+deploy:
+	@if [ -z "$(CODE_BUCKET)" ]; then echo "ERROR: CODE_BUCKET is required. Usage: make deploy CODE_BUCKET=<bucket>"; exit 1; fi
+	cd scripts && ./deploy.sh \
+	  --code-bucket "$(CODE_BUCKET)" \
+	  $(if $(ENV),--env "$(ENV)") \
+	  $(if $(REGION),--region "$(REGION)") \
+	  $(if $(VPC_ID),--vpc-id "$(VPC_ID)") \
+	  $(if $(SUBNETS),--subnets "$(SUBNETS)") \
+	  $(if $(STUDENT_KEY),--student-key "$(STUDENT_KEY)") \
+	  $(if $(filter true,$(SKIP_TEST)),--skip-test) \
+	  $(if $(filter true,$(SKIP_ECS)),--skip-ecs)
 
 install: install-a install-b
 

--- a/sast-platform/Makefile
+++ b/sast-platform/Makefile
@@ -7,9 +7,12 @@ help:
 	@echo "Usage: make <target>"
 	@echo ""
 	@echo "  deploy         Full-stack deploy (requires CODE_BUCKET)"
-	@echo "                 make deploy CODE_BUCKET=my-bucket [ENV=dev] [REGION=us-east-1]"
-	@echo "                 make deploy CODE_BUCKET=my-bucket VPC_ID=vpc-xxx SUBNETS=subnet-xxx"
-	@echo "                 make deploy CODE_BUCKET=my-bucket STUDENT_KEY=abc123  (+ smoke test)"
+	@echo "                 make deploy CODE_BUCKET=my-bucket"
+	@echo "                 make deploy CODE_BUCKET=my-bucket ENV=prod REGION=us-west-2"
+	@echo "                 make deploy CODE_BUCKET=my-bucket VPC_ID=vpc-xxx SUBNETS=subnet-aaa"
+	@echo "                 make deploy CODE_BUCKET=my-bucket SCANNER_IMAGE=<ecr-uri>"
+	@echo "                 make deploy CODE_BUCKET=my-bucket STUDENT_KEY=abc  (+ smoke test)"
+	@echo "                 make deploy CODE_BUCKET=my-bucket SKIP_ECS=1 SKIP_TEST=1"
 	@echo "  install        Install test deps for both Lambda A and B"
 	@echo "  install-a      Install Lambda A deps only"
 	@echo "  install-b      Install Lambda B deps only"
@@ -27,9 +30,10 @@ deploy:
 	  $(if $(REGION),--region "$(REGION)") \
 	  $(if $(VPC_ID),--vpc-id "$(VPC_ID)") \
 	  $(if $(SUBNETS),--subnets "$(SUBNETS)") \
+	  $(if $(SCANNER_IMAGE),--scanner-image "$(SCANNER_IMAGE)") \
 	  $(if $(STUDENT_KEY),--student-key "$(STUDENT_KEY)") \
-	  $(if $(filter true,$(SKIP_TEST)),--skip-test) \
-	  $(if $(filter true,$(SKIP_ECS)),--skip-ecs)
+	  $(if $(SKIP_TEST),--skip-test) \
+	  $(if $(SKIP_ECS),--skip-ecs)
 
 install: install-a install-b
 

--- a/sast-platform/scripts/deploy.sh
+++ b/sast-platform/scripts/deploy.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# deploy.sh — Single-command full-stack deployment for the SAST Platform.
+#
+# Runs all deployment steps in order:
+#   1. 01_setup_infra.sh    → CloudFormation stacks (S3, DynamoDB, SQS, Lambda A/B, ECS, CloudWatch)
+#   2. 02_deploy_lambda_a.sh → Package and deploy Lambda A code
+#   3. 03_deploy_lambda_b.sh → Package and deploy Lambda B code
+#   4. 04_build_ecs_image.sh → Build and push ECS scanner image (only if --vpc-id is set)
+#   5. 04_upload_frontend.sh → Inject Lambda URL and sync frontend to S3
+#   6. 05_test_api.sh       → End-to-end smoke test (requires --student-key)
+#
+# Usage:
+#   ./deploy.sh --code-bucket <bucket> [OPTIONS]
+#
+# Required:
+#   --code-bucket    S3 bucket for Lambda deployment packages
+#
+# Optional:
+#   --project        Project name prefix        (default: sast-platform)
+#   --env            Deployment environment      (default: dev)
+#   --region         AWS region                 (default: us-east-1)
+#   --vpc-id         VPC ID — enables ECS Fargate stack + ECS image build
+#   --subnets        Comma-separated subnet IDs  (required with --vpc-id)
+#   --scanner-image  ECR image URI override for ECS scanner
+#   --student-key    API key for smoke test      (skips 05_test_api.sh if omitted)
+#   --skip-ecs       Skip ECS image build even when --vpc-id is provided
+#   --skip-test      Skip end-to-end smoke test unconditionally
+#
+# Environment variable equivalents (flags take precedence):
+#   CODE_BUCKET, PROJECT_NAME, ENVIRONMENT, AWS_REGION,
+#   VPC_ID, SUBNET_IDS, SCANNER_IMAGE, STUDENT_KEY, SKIP_TEST
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+PROJECT_NAME="${PROJECT_NAME:-sast-platform}"
+ENVIRONMENT="${ENVIRONMENT:-dev}"
+AWS_REGION="${AWS_REGION:-us-east-1}"
+CODE_BUCKET="${CODE_BUCKET:-}"
+VPC_ID="${VPC_ID:-}"
+SUBNET_IDS="${SUBNET_IDS:-}"
+SCANNER_IMAGE="${SCANNER_IMAGE:-}"
+STUDENT_KEY="${STUDENT_KEY:-}"
+SKIP_TEST="${SKIP_TEST:-false}"
+SKIP_ECS=false
+
+# ── Argument parsing ───────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --code-bucket)   CODE_BUCKET="$2";    shift 2 ;;
+    --project)       PROJECT_NAME="$2";   shift 2 ;;
+    --env)           ENVIRONMENT="$2";    shift 2 ;;
+    --region)        AWS_REGION="$2";     shift 2 ;;
+    --vpc-id)        VPC_ID="$2";         shift 2 ;;
+    --subnets)       SUBNET_IDS="$2";     shift 2 ;;
+    --scanner-image) SCANNER_IMAGE="$2";  shift 2 ;;
+    --student-key)   STUDENT_KEY="$2";    shift 2 ;;
+    --skip-ecs)      SKIP_ECS=true;       shift   ;;
+    --skip-test)     SKIP_TEST="true";    shift   ;;
+    *) echo "ERROR: Unknown argument: $1"; exit 1 ;;
+  esac
+done
+
+# ── Validation ─────────────────────────────────────────────────────────────────
+if [[ -z "$CODE_BUCKET" ]]; then
+  echo "ERROR: --code-bucket is required."
+  echo "       Usage: ./deploy.sh --code-bucket <s3-bucket> [OPTIONS]"
+  exit 1
+fi
+
+if [[ -n "$VPC_ID" && -z "$SUBNET_IDS" ]]; then
+  echo "ERROR: --subnets is required when --vpc-id is set."
+  exit 1
+fi
+
+# ── Export env vars consumed by child scripts ─────────────────────────────────
+export PROJECT_NAME ENVIRONMENT AWS_REGION CODE_BUCKET SKIP_TEST
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+step() { echo ""; echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"; echo "[$1/6] $2"; echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"; }
+ok()   { echo "[$(date '+%H:%M:%S')] ✓ $*"; }
+
+get_cf_output() {
+  local stack="$1" key="$2"
+  aws cloudformation describe-stacks \
+    --stack-name "$stack" \
+    --region "$AWS_REGION" \
+    --query "Stacks[0].Outputs[?OutputKey=='$key'].OutputValue" \
+    --output text 2>/dev/null || true
+}
+
+# ── Banner ────────────────────────────────────────────────────────────────────
+echo ""
+echo "╔══════════════════════════════════════════════════════╗"
+echo "║         SAST Platform — Full-Stack Deploy            ║"
+echo "╠══════════════════════════════════════════════════════╣"
+printf "║  Project:    %-38s ║\n" "$PROJECT_NAME"
+printf "║  Environment:%-38s ║\n" "$ENVIRONMENT"
+printf "║  Region:     %-38s ║\n" "$AWS_REGION"
+printf "║  Code Bucket:%-38s ║\n" "$CODE_BUCKET"
+if [[ -n "$VPC_ID" && "$SKIP_ECS" == "false" ]]; then
+printf "║  ECS:        %-38s ║\n" "enabled (VPC: $VPC_ID)"
+else
+printf "║  ECS:        %-38s ║\n" "skipped"
+fi
+printf "║  Smoke test: %-38s ║\n" "$([[ -n "$STUDENT_KEY" && "$SKIP_TEST" != "true" ]] && echo "enabled" || echo "skipped")"
+echo "╚══════════════════════════════════════════════════════╝"
+
+# ── Step 1: CloudFormation infrastructure ─────────────────────────────────────
+step 1 "Deploying CloudFormation stacks (infra)"
+
+INFRA_ARGS=(
+  --code-bucket "$CODE_BUCKET"
+  --project     "$PROJECT_NAME"
+  --env         "$ENVIRONMENT"
+  --region      "$AWS_REGION"
+)
+[[ -n "$VPC_ID" ]]       && INFRA_ARGS+=(--vpc-id "$VPC_ID")
+[[ -n "$SUBNET_IDS" ]]   && INFRA_ARGS+=(--subnets "$SUBNET_IDS")
+[[ -n "$SCANNER_IMAGE" ]] && INFRA_ARGS+=(--scanner-image "$SCANNER_IMAGE")
+
+"$SCRIPT_DIR/01_setup_infra.sh" "${INFRA_ARGS[@]}"
+ok "Infrastructure stacks deployed"
+
+# ── Step 2: Lambda A ──────────────────────────────────────────────────────────
+step 2 "Deploying Lambda A (API layer)"
+
+"$SCRIPT_DIR/02_deploy_lambda_a.sh" \
+  --code-bucket "$CODE_BUCKET" \
+  --project     "$PROJECT_NAME" \
+  --env         "$ENVIRONMENT" \
+  --region      "$AWS_REGION" \
+  --skip-test
+ok "Lambda A deployed"
+
+# ── Step 3: Lambda B ──────────────────────────────────────────────────────────
+step 3 "Deploying Lambda B (scanner engine)"
+
+# 03_deploy_lambda_b.sh reads PROJECT_NAME, ENVIRONMENT, AWS_REGION, CODE_BUCKET from env
+SKIP_TEST="true" "$SCRIPT_DIR/03_deploy_lambda_b.sh"
+ok "Lambda B deployed"
+
+# ── Step 4: ECS image (optional) ──────────────────────────────────────────────
+if [[ -n "$VPC_ID" && "$SKIP_ECS" == "false" ]]; then
+  step 4 "Building and pushing ECS scanner image"
+  SKIP_TEST="true" "$SCRIPT_DIR/04_build_ecs_image.sh"
+  ok "ECS image built and pushed"
+else
+  step 4 "ECS image build — skipped"
+  echo "(pass --vpc-id and omit --skip-ecs to enable)"
+fi
+
+# ── Step 5: Frontend ──────────────────────────────────────────────────────────
+step 5 "Uploading frontend to S3"
+
+"$SCRIPT_DIR/04_upload_frontend.sh" \
+  --project "$PROJECT_NAME" \
+  --env     "$ENVIRONMENT" \
+  --region  "$AWS_REGION"
+ok "Frontend uploaded"
+
+# ── Step 6: Smoke test (optional) ─────────────────────────────────────────────
+step 6 "End-to-end smoke test"
+
+if [[ "$SKIP_TEST" == "true" ]]; then
+  echo "Skipped (--skip-test)"
+elif [[ -z "$STUDENT_KEY" ]]; then
+  echo "Skipped (no --student-key provided)."
+  echo "To run manually:"
+  LAMBDA_URL="$(get_cf_output "${PROJECT_NAME}-lambda-a" LambdaAFunctionUrl)"
+  echo "  LAMBDA_URL=$LAMBDA_URL \\"
+  echo "  STUDENT_KEY=<your-key> \\"
+  echo "  ./05_test_api.sh"
+else
+  LAMBDA_URL="$(get_cf_output "${PROJECT_NAME}-lambda-a" LambdaAFunctionUrl)"
+  if [[ -z "$LAMBDA_URL" || "$LAMBDA_URL" == "None" ]]; then
+    echo "WARNING: Could not resolve Lambda A URL from CloudFormation — skipping smoke test."
+  else
+    "$SCRIPT_DIR/05_test_api.sh" --url "$LAMBDA_URL" --key "$STUDENT_KEY"
+    ok "Smoke test passed"
+  fi
+fi
+
+# ── Final summary ─────────────────────────────────────────────────────────────
+LAMBDA_URL="$(get_cf_output "${PROJECT_NAME}-lambda-a" LambdaAFunctionUrl || true)"
+FRONTEND_URL="$(get_cf_output "${PROJECT_NAME}-s3" FrontendWebsiteURL || true)"
+
+echo ""
+echo "╔══════════════════════════════════════════════════════╗"
+echo "║            Deployment Complete                       ║"
+echo "╠══════════════════════════════════════════════════════╣"
+printf "║  Lambda A URL:   %-34s ║\n" "${LAMBDA_URL:-<check console>}"
+printf "║  Frontend URL:   %-34s ║\n" "${FRONTEND_URL:-<check console>}"
+echo "╠══════════════════════════════════════════════════════╣"
+echo "║  Seed API keys:                                      ║"
+printf "║  %-52s ║\n" "python scripts/00_seed_auth.py \\"
+printf "║  %-52s ║\n" "  --table StudentAuth --add-student <id>"
+echo "╚══════════════════════════════════════════════════════╝"
+echo ""


### PR DESCRIPTION
## Summary

- Add `scripts/deploy.sh` — wraps all five deployment steps into one command
- Add `make deploy` target to `Makefile` for convenience

## Usage

```bash
# Minimal (Lambda + frontend only, no ECS, no smoke test)
./scripts/deploy.sh --code-bucket my-bucket

# With ECS Fargate and smoke test
./scripts/deploy.sh \
  --code-bucket my-bucket \
  --vpc-id vpc-xxx \
  --subnets subnet-aaa,subnet-bbb \
  --student-key abc123

# Via Make
make deploy CODE_BUCKET=my-bucket
make deploy CODE_BUCKET=my-bucket VPC_ID=vpc-xxx SUBNETS=subnet-aaa STUDENT_KEY=abc123
```

## What deploy.sh does

| Step | Script | Notes |
|------|--------|-------|
| 1 | `01_setup_infra.sh` | All CloudFormation stacks |
| 2 | `02_deploy_lambda_a.sh` | Lambda A code |
| 3 | `03_deploy_lambda_b.sh` | Lambda B code |
| 4 | `04_build_ecs_image.sh` | Only if `--vpc-id` is set and `--skip-ecs` is not |
| 5 | `04_upload_frontend.sh` | Injects Lambda URL, syncs to S3 |
| 6 | `05_test_api.sh` | Only if `--student-key` is provided |

All existing scripts are unchanged. `deploy.sh` is a pure wrapper.

## Test plan

- [ ] `bash -n scripts/deploy.sh` passes (syntax check)
- [ ] `make deploy` without `CODE_BUCKET` prints a clear error
- [ ] `make help` shows the new `deploy` target
- [ ] Full deploy runs end-to-end on a real AWS account

🤖 Generated with [Claude Code](https://claude.com/claude-code)