### PR TITLE
fix: load API URL from runtime config.json instead of baking it into app.js

### DIFF
--- a/sast-platform/frontend/js/app.js
+++ b/sast-platform/frontend/js/app.js
@@ -11,8 +11,10 @@ let API_BASE_URL = null;
 
 async function initConfig() {
   const res = await fetch("/config.json");
+  if (!res.ok) throw new Error(`config.json fetch failed: HTTP ${res.status}`);
   const cfg = await res.json();
-  API_BASE_URL = (cfg.apiUrl || "").replace(/\/$/, "");
+  if (!cfg.apiUrl) throw new Error("config.json is missing required field: apiUrl");
+  API_BASE_URL = cfg.apiUrl.replace(/\/$/, "");
 }
 
 const POLL_INITIAL_MS  = 2000;

--- a/sast-platform/frontend/js/app.js
+++ b/sast-platform/frontend/js/app.js
@@ -2,11 +2,18 @@
  * app.js — Frontend logic
  * CS6620 Group 9
  *
- * API_BASE_URL is replaced at deploy time by 04_upload_frontend.sh
- * using: sed -i "s|__LAMBDA_URL__|$LAMBDA_URL|g" app.js
+ * API_BASE_URL is loaded at runtime from /config.json (written to S3 by
+ * 04_upload_frontend.sh). This avoids baking the URL into the JS bundle,
+ * so the endpoint can be updated by re-deploying config.json alone.
  */
 
-const API_BASE_URL = "__LAMBDA_URL__";
+let API_BASE_URL = null;
+
+async function initConfig() {
+  const res = await fetch("/config.json");
+  const cfg = await res.json();
+  API_BASE_URL = (cfg.apiUrl || "").replace(/\/$/, "");
+}
 
 const POLL_INITIAL_MS  = 2000;
 const POLL_BACKOFF     = 1.5;
@@ -71,7 +78,8 @@ function switchView(name) {
 
 // ── Init ──────────────────────────────────────────────────────────────────────
 
-document.addEventListener("DOMContentLoaded", () => {
+document.addEventListener("DOMContentLoaded", async () => {
+  await initConfig();
   initDarkMode();
   initTheme();
   // Restore student ID — show login modal if none saved

--- a/sast-platform/scripts/04_upload_frontend.sh
+++ b/sast-platform/scripts/04_upload_frontend.sh
@@ -122,7 +122,10 @@ get_lambda_url_from_cf() {
   echo "${url%/}"
 }
 
-# ── Build step: copy to temp dir and inject Lambda URL ────────────────────────
+# ── Build step: copy to temp dir and write config.json ───────────────────────
+#
+# config.json is fetched at runtime by app.js — no URL is baked into the JS
+# bundle, so updating the endpoint only requires re-deploying this one file.
 
 build_frontend() {
   local lambda_url="$1"
@@ -132,22 +135,13 @@ build_frontend() {
   cp -r "$FRONTEND_DIR/." "$BUILD_DIR/"
 
   if [[ "$SKIP_INJECT" == "true" ]]; then
-    warn "Skipping URL injection (--skip-inject). API_BASE_URL will remain as placeholder."
+    warn "Skipping config.json generation (--skip-inject)."
     return
   fi
 
-  local app_js="$BUILD_DIR/js/app.js"
-
-  if grep -q "__LAMBDA_URL__" "$app_js"; then
-    # sed -i behaves differently on macOS vs Linux
-    # Use a .bak pattern that works on both
-    sed -i.bak "s|__LAMBDA_URL__|${lambda_url}|g" "$app_js" && rm -f "${app_js}.bak"
-    log "Injected Lambda URL into js/app.js"
-    log "  API_BASE_URL = \"$lambda_url\""
-  else
-    warn "__LAMBDA_URL__ placeholder not found in app.js — URL injection skipped."
-    warn "The frontend will not be able to reach the backend."
-  fi
+  printf '{"apiUrl":"%s"}' "$lambda_url" > "$BUILD_DIR/config.json"
+  log "Generated config.json"
+  log "  apiUrl = \"$lambda_url\""
 }
 
 # ── Upload: sync each file type with correct Content-Type ─────────────────────
@@ -181,7 +175,7 @@ upload_frontend() {
     --cache-control "no-cache, no-store, must-revalidate"
   log "  ✓ CSS uploaded"
 
-  # JavaScript — no-cache because app.js embeds the injected Lambda URL
+  # JavaScript
   aws s3 sync "$BUILD_DIR" "s3://$FRONTEND_BUCKET" \
     --region "$AWS_REGION" \
     --delete \
@@ -190,6 +184,15 @@ upload_frontend() {
     --content-type "application/javascript; charset=utf-8" \
     --cache-control "no-cache, no-store, must-revalidate"
   log "  ✓ JavaScript uploaded"
+
+  # config.json — no-cache so URL changes are picked up immediately
+  if [[ -f "$BUILD_DIR/config.json" ]]; then
+    aws s3 cp "$BUILD_DIR/config.json" "s3://$FRONTEND_BUCKET/config.json" \
+      --region "$AWS_REGION" \
+      --content-type "application/json" \
+      --cache-control "no-cache, no-store, must-revalidate"
+    log "  ✓ config.json uploaded"
+  fi
 
   # Everything else (favicon, fonts, images…) — no explicit Content-Type override
   aws s3 sync "$BUILD_DIR" "s3://$FRONTEND_BUCKET" \

--- a/sast-platform/scripts/04_upload_frontend.sh
+++ b/sast-platform/scripts/04_upload_frontend.sh
@@ -4,7 +4,7 @@
 # What it does:
 #   1. Pre-flight: verifies AWS CLI, credentials, and bucket existence
 #   2. Reads Lambda A Function URL from CloudFormation outputs
-#   3. Injects the URL into app.js via the __LAMBDA_URL__ placeholder
+#   3. Writes the API URL into config.json (fetched at runtime by app.js)
 #   4. Syncs all frontend files to the S3 frontend bucket with correct
 #      Content-Type headers per file type
 #   5. Prints the live S3 website URL


### PR DESCRIPTION
## Problem

`04_upload_frontend.sh` used `sed` to replace the `__LAMBDA_URL__` placeholder inside `app.js` before uploading to S3. This baked the API Gateway URL directly into the JS bundle, which caused two issues:

1. Any URL change (e.g. Learner Lab session restart creates a new API Gateway endpoint) required a full frontend redeploy
2. The deployed `app.js` always had a hardcoded URL — easy to get stale

## Solution

Move the API URL out of the JS bundle into a separate `config.json` file that is fetched at runtime.

### `frontend/js/app.js`
- Replace `const API_BASE_URL = "__LAMBDA_URL__"` with `let API_BASE_URL = null`
- Add `async initConfig()` that fetches `/config.json` and reads `cfg.apiUrl`
- Make `DOMContentLoaded` handler `async` and `await initConfig()` before any other setup

### `scripts/04_upload_frontend.sh`
- Remove the `sed` replacement of `__LAMBDA_URL__` in `app.js`
- Write `{"apiUrl": "<url>"}` to `config.json` in the build directory
- Upload `config.json` to S3 with `no-cache` headers

## Result

- `app.js` in the repo is clean — no placeholder, no hardcoded URL
- To update the endpoint after a Learner Lab restart: just re-run `04_upload_frontend.sh` (same as before), or upload `config.json` directly to S3
- JS/CSS/HTML can now be cached independently of the API URL

## Test plan
- [ ] Run `04_upload_frontend.sh` — verify `config.json` is uploaded to S3
- [ ] Open frontend — verify `fetch("/config.json")` succeeds in browser Network tab
- [ ] Submit a scan — verify it reaches the correct API Gateway URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)