### PR TITLE
fix: replace hardcoded config values with env-var overrides

### DIFF
--- a/sast-platform/lambda_a/dispatcher.py
+++ b/sast-platform/lambda_a/dispatcher.py
@@ -7,6 +7,7 @@ Called after validation passes.
 """
 
 import json
+import os
 import time
 import uuid
 import logging
@@ -22,7 +23,7 @@ sqs      = boto3.client("sqs")
 dynamodb = boto3.resource("dynamodb")
 s3       = boto3.client("s3")
 
-RATE_LIMIT_PER_HOUR = 10
+RATE_LIMIT_PER_HOUR = int(os.environ.get("RATE_LIMIT_PER_HOUR", "10"))
 
 
 def check_rate_limit(student_id: str, table_name: str,

--- a/sast-platform/lambda_a/history.py
+++ b/sast-platform/lambda_a/history.py
@@ -11,6 +11,7 @@ needing a GSI — student_id is already the partition key.
 """
 
 import logging
+import os
 
 import boto3
 from boto3.dynamodb.conditions import Key
@@ -21,7 +22,7 @@ logger.setLevel(logging.INFO)
 
 dynamodb = boto3.resource("dynamodb")
 
-MAX_HISTORY_ITEMS = 50
+MAX_HISTORY_ITEMS = int(os.environ.get("MAX_HISTORY_ITEMS", "50"))
 
 
 def get_scan_history(student_id: str, table_name: str) -> list:

--- a/sast-platform/lambda_a/status.py
+++ b/sast-platform/lambda_a/status.py
@@ -8,6 +8,7 @@ so the frontend can fetch the report directly.
 """
 
 import logging
+import os
 from datetime import datetime, timedelta, timezone
 
 import boto3
@@ -19,16 +20,16 @@ logger.setLevel(logging.INFO)
 dynamodb = boto3.resource("dynamodb")
 s3       = boto3.client("s3")
 
-PRESIGNED_URL_EXPIRY   = 3600   # seconds (1 hour)
-SCAN_TTL_HOURS         = 1      # scans older than this are considered expired
-POLLING_INTERVAL_S     = 5      # suggested client poll interval (seconds)
-ECS_POLLING_INTERVAL_S = 30     # ECS tasks take longer — poll less aggressively
+PRESIGNED_URL_EXPIRY   = int(os.environ.get("PRESIGNED_URL_EXPIRY_SECONDS", "3600"))   # default 1 hour
+SCAN_TTL_HOURS         = int(os.environ.get("SCAN_TTL_HOURS", "1"))
+POLLING_INTERVAL_S     = int(os.environ.get("POLLING_INTERVAL_SECONDS", "5"))
+ECS_POLLING_INTERVAL_S = int(os.environ.get("ECS_POLLING_INTERVAL_SECONDS", "30"))
 
 # A scan stuck IN_PROGRESS longer than this threshold is considered stale:
 # Lambda B crashed or was OOM-killed before writing DONE/FAILED.
 # Covers Lambda B max timeout (900 s / 15 min) AND ECS Fargate scan timeout
 # (1800 s / 30 min) plus a 5-minute buffer.
-_STALE_IN_PROGRESS_MINUTES = 35
+_STALE_IN_PROGRESS_MINUTES = int(os.environ.get("STALE_SCAN_TIMEOUT_MINUTES", "35"))
 
 
 def get_scan_status(scan_id: str, student_id: str, table_name: str, s3_bucket: str) -> dict:

--- a/sast-platform/lambda_a/validator.py
+++ b/sast-platform/lambda_a/validator.py
@@ -6,8 +6,10 @@ Input validation for POST /scan requests.
 All validation logic is isolated here so it can be unit tested independently.
 """
 
+import os
+
 SUPPORTED_LANGUAGES = ["python", "java", "javascript", "typescript", "go", "ruby", "c", "cpp"]
-MAX_CODE_BYTES = 1 * 1024 * 1024  # 1 MB
+MAX_CODE_BYTES = int(os.environ.get("MAX_CODE_BYTES", str(1 * 1024 * 1024)))  # default 1 MB
 
 
 def validate_scan_request(body: dict) -> tuple[bool, str]:

--- a/sast-platform/lambda_b/handler.py
+++ b/sast-platform/lambda_b/handler.py
@@ -56,7 +56,7 @@ logger.setLevel(logging.INFO)
 # Code size threshold for ECS fallback.
 # Submissions larger than this are offloaded to ECS Fargate instead of
 # being scanned inline, avoiding Lambda timeout/memory limits.
-LAMBDA_CODE_SIZE_LIMIT = 250_000  # ~250 KB
+LAMBDA_CODE_SIZE_LIMIT = int(os.environ.get("LAMBDA_CODE_SIZE_LIMIT", str(250_000)))  # ~250 KB
 
 # Initialize AWS clients
 dynamodb = boto3.resource('dynamodb')
@@ -248,7 +248,8 @@ def process_scan_request(scan_id: str, language: str, student_id: str,
 
         # Step 2: Execute security scan (inline for small submissions)
         logger.info(f"Starting scan - scan_id: {scan_id}")
-        raw_scan_result = scan_code_with_timeout(code, language, scan_id, timeout=300)
+        raw_scan_result = scan_code_with_timeout(code, language, scan_id,
+                                                  timeout=int(os.environ.get("SCAN_TIMEOUT_SECONDS", "300")))
 
         # Step 3: Parse scan results
         logger.info(f"Parsing scan results - scan_id: {scan_id}")

--- a/sast-platform/lambda_b/s3_writer.py
+++ b/sast-platform/lambda_b/s3_writer.py
@@ -15,10 +15,10 @@ class S3WriteError(Exception):
 class S3Writer:
     """Save scan reports to S3."""
 
-    def __init__(self, bucket_name, region="us-east-1"):
+    def __init__(self, bucket_name, region=None):
         self.bucket_name = bucket_name
-        self.region = region
-        self.s3_client = boto3.client("s3", region_name=region)
+        self.region = region or os.environ.get("AWS_REGION", "us-east-1")
+        self.s3_client = boto3.client("s3", region_name=self.region)
 
     def write_scan_report(self, scan_id, report_data, student_id):
         """Upload a scan report and return the S3 key."""
@@ -112,7 +112,7 @@ class S3Writer:
         )
 
 
-def write_scan_result_to_s3(bucket_name, scan_id, student_id, report_data, region="us-east-1"):
+def write_scan_result_to_s3(bucket_name, scan_id, student_id, report_data, region=None):
     """Save result to S3 and return key + URL."""
     writer = S3Writer(bucket_name, region)
     s3_key = writer.write_scan_report(scan_id, report_data, student_id)


### PR DESCRIPTION
## Problem (closes #107)

Several production files had hardcoded configuration values that cannot be tuned without changing source code. The most critical was `region="us-east-1"` in `s3_writer.py`, which silently breaks any deployment to a non-`us-east-1` region because boto3 ignores `AWS_REGION` when an explicit value is supplied.

## Changes

| File | What was hardcoded | Env var to override |
|------|--------------------|---------------------|
| `lambda_b/s3_writer.py` | `region="us-east-1"` (×2) | `AWS_REGION` |
| `lambda_a/dispatcher.py` | `RATE_LIMIT_PER_HOUR = 10` | `RATE_LIMIT_PER_HOUR` |
| `lambda_b/handler.py` | `LAMBDA_CODE_SIZE_LIMIT = 250_000` | `LAMBDA_CODE_SIZE_LIMIT` |
| `lambda_b/handler.py` | `timeout=300` (scan timeout) | `SCAN_TIMEOUT_SECONDS` |
| `lambda_a/history.py` | `MAX_HISTORY_ITEMS = 50` | `MAX_HISTORY_ITEMS` |
| `lambda_a/validator.py` | `MAX_CODE_BYTES = 1 MB` | `MAX_CODE_BYTES` |
| `lambda_a/status.py` | presigned URL expiry, poll intervals, TTL, stale-scan timeout | `PRESIGNED_URL_EXPIRY_SECONDS`, `SCAN_TTL_HOURS`, `POLLING_INTERVAL_SECONDS`, `ECS_POLLING_INTERVAL_SECONDS`, `STALE_SCAN_TIMEOUT_MINUTES` |

All original values are kept as defaults — **no behaviour change** unless the env var is explicitly set.

## Test plan
- [ ] Deploy to a non-`us-east-1` region and verify S3 operations use the correct region
- [ ] Set `RATE_LIMIT_PER_HOUR=5` on Lambda A and confirm the lower limit is enforced
- [ ] Set `SCAN_TIMEOUT_SECONDS=60` on Lambda B and confirm short timeout is respected
- [ ] Unit tests pass unchanged (all defaults match the previous hardcoded values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)