### PR TITLE
feat: add line numbers to code input editor

### DIFF
--- a/sast-platform/frontend/css/style.css
+++ b/sast-platform/frontend/css/style.css
@@ -419,6 +419,31 @@ body {
 
 .drop-zone.drag-over .drop-hint { color: var(--accent); }
 
+.code-editor-wrap {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.line-numbers {
+  background: transparent;
+  border-right: 1px solid var(--border);
+  color: var(--text-muted);
+  font-family: "SF Mono", "Fira Code", "Consolas", monospace;
+  font-size: 14px;
+  line-height: 1.65;
+  padding: 12px 10px 12px 8px;
+  text-align: right;
+  user-select: none;
+  pointer-events: none;
+  overflow: hidden;
+  min-width: 2em;
+  flex-shrink: 0;
+  white-space: pre;
+  opacity: 0.5;
+}
+
 .code-input {
   flex: 1;
   margin: 0;
@@ -429,7 +454,7 @@ body {
   font-family: "SF Mono", "Fira Code", "Consolas", monospace;
   font-size: 14px;
   line-height: 1.65;
-  padding: 12px 14px;
+  padding: 12px 14px 12px 10px;
   resize: none;
   outline: none;
   min-height: 0;

--- a/sast-platform/frontend/index.html
+++ b/sast-platform/frontend/index.html
@@ -123,9 +123,12 @@
               <span class="drop-hint">⬇ Drop a file here, or paste code below</span>
               <button class="btn-clear-code" id="btn-clear-code" onclick="clearCode()" title="Clear code">✕ Clear</button>
             </div>
-            <textarea id="code" class="code-input"
-                      placeholder="Paste your code here..." spellcheck="false"
-                      oninput="updateCodeStats()"></textarea>
+            <div class="code-editor-wrap">
+              <div class="line-numbers" id="line-numbers">1</div>
+              <textarea id="code" class="code-input"
+                        placeholder="Paste your code here..." spellcheck="false"
+                        oninput="updateCodeStats()"></textarea>
+            </div>
             <div class="code-stats" id="code-stats"></div>
           </div>
 

--- a/sast-platform/frontend/js/app.js
+++ b/sast-platform/frontend/js/app.js
@@ -141,6 +141,12 @@ document.addEventListener("DOMContentLoaded", () => {
     };
     reader.readAsText(file);
   });
+
+  // Sync line-number gutter scroll with textarea scroll
+  document.getElementById("code").addEventListener("scroll", () => {
+    const lineNumbers = document.getElementById("line-numbers");
+    if (lineNumbers) lineNumbers.scrollTop = document.getElementById("code").scrollTop;
+  });
 });
 
 function setStudentIdHint(id) {
@@ -641,11 +647,22 @@ function dismissError() {
 
 // ── Code stats ───────────────────────────────────────────────────────────────
 
+function updateLineNumbers() {
+  const textarea    = document.getElementById("code");
+  const lineNumbers = document.getElementById("line-numbers");
+  if (!lineNumbers) return;
+  const count = textarea.value ? textarea.value.split("\n").length : 1;
+  lineNumbers.textContent = Array.from({ length: count }, (_, i) => i + 1).join("\n");
+  lineNumbers.scrollTop = textarea.scrollTop;
+}
+
 function updateCodeStats() {
   const code  = document.getElementById("code").value;
   const stats = document.getElementById("code-stats");
   const clearBtn = document.getElementById("btn-clear-code");
   if (!stats) return;
+
+  updateLineNumbers();
 
   if (!code) {
     stats.textContent = "";


### PR DESCRIPTION
## What

Adds a line-number gutter to the left of the code input textarea so users can immediately see which line they are on.

## How it works

- A `<div id="line-numbers">` is placed in a flex wrapper alongside the `<textarea>`, sharing the same monospace font, font-size, and line-height so numbers stay pixel-perfectly aligned with every line of code
- `updateLineNumbers()` regenerates the gutter content (`1\n2\n3…`) on every keystroke; it is called from the existing `updateCodeStats()`
- A `scroll` event listener on the textarea mirrors `scrollTop` to the gutter so the numbers stay in sync when the user scrolls
- The gutter is `user-select: none; pointer-events: none` — it never interferes with text selection or copy-paste

## Files changed

| File | Change |
|------|--------|
| `frontend/index.html` | Wrap textarea in `.code-editor-wrap` + add `#line-numbers` div |
| `frontend/css/style.css` | Add `.code-editor-wrap` (flex row) and `.line-numbers` styles |
| `frontend/js/app.js` | Add `updateLineNumbers()`, call it from `updateCodeStats()`, add scroll sync listener |

🤖 Generated with [Claude Code](https://claude.com/claude-code)