### PR TITLE
fix: add pattern scanner fallback for JS/TS scans in Lambda

### DIFF
--- a/sast-platform/lambda_b/handler.py
+++ b/sast-platform/lambda_b/handler.py
@@ -239,7 +239,9 @@ def process_scan_request(scan_id: str, language: str, student_id: str,
         # Route large Python submissions to ECS to avoid Lambda timeout/OOM.
         code_bytes = len(code.encode('utf-8'))
         semgrep_languages = {'java', 'javascript', 'typescript', 'go', 'ruby', 'c', 'cpp'}
-        needs_ecs = (code_bytes > LAMBDA_CODE_SIZE_LIMIT) or (language.lower() in semgrep_languages)
+        needs_ecs = ecs_configured and (
+            (code_bytes > LAMBDA_CODE_SIZE_LIMIT) or (language.lower() in semgrep_languages)
+        )
         if needs_ecs:
             reason = (
                 f"code size {code_bytes} bytes exceeds {LAMBDA_CODE_SIZE_LIMIT} limit"

--- a/sast-platform/lambda_b/pattern_scanner.py
+++ b/sast-platform/lambda_b/pattern_scanner.py
@@ -1,0 +1,191 @@
+"""
+Lightweight regex-based security scanner for JavaScript/TypeScript and other languages.
+Used as a Lambda-native fallback when ECS/semgrep is not available.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Tuple
+
+
+# Each rule: (rule_id, severity, confidence, pattern, description)
+# Prefix "cs:" means case-sensitive match; otherwise re.IGNORECASE is used.
+_RULES: List[Tuple[str, str, str, str, str]] = [
+    # ── Hardcoded Secrets ──────────────────────────────────────────────────
+    (
+        "cs:secrets.stripe-api-key",
+        "HIGH", "HIGH",
+        r'sk_(live|test)_[A-Za-z0-9]{20,}',
+        "Hardcoded Stripe API key detected",
+    ),
+    (
+        "cs:secrets.aws-access-key",
+        "HIGH", "HIGH",
+        r'AKIA[0-9A-Z]{16}',
+        "Hardcoded AWS access key ID detected",
+    ),
+    (
+        "secrets.hardcoded-password",
+        "HIGH", "MEDIUM",
+        r'(password|passwd|pwd|secret|api_?key|auth_?token)\s*[=:]\s*["\'][^"\']{6,}["\']',
+        "Hardcoded credential or secret value detected",
+    ),
+    (
+        "secrets.connection-string-credentials",
+        "HIGH", "HIGH",
+        r'(mongodb|mysql|postgres|postgresql|mssql|redis|amqp)://[^@\s]+:[^@\s]+@',
+        "Database connection string contains embedded credentials",
+    ),
+    (
+        "secrets.github-token",
+        "HIGH", "HIGH",
+        r'gh[pousr]_[A-Za-z0-9]{36,}',
+        "Hardcoded GitHub personal access token detected",
+    ),
+    (
+        "secrets.generic-private-key",
+        "HIGH", "HIGH",
+        r'-----BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----',
+        "Private key material found in source code",
+    ),
+    (
+        "secrets.jwt-token",
+        "MEDIUM", "MEDIUM",
+        r'eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}',
+        "Hardcoded JWT token detected",
+    ),
+
+    # ── Dangerous Functions ────────────────────────────────────────────────
+    (
+        "injection.eval",
+        "HIGH", "MEDIUM",
+        r'\beval\s*\(',
+        "Use of eval() can lead to code injection",
+    ),
+    (
+        "injection.function-constructor",
+        "HIGH", "MEDIUM",
+        r'\bnew\s+Function\s*\(',
+        "Use of new Function() is equivalent to eval() and can lead to code injection",
+    ),
+    (
+        "injection.child-process-exec",
+        "HIGH", "MEDIUM",
+        r'\b(child_process\s*\.\s*exec|execSync\s*\(|spawnSync\s*\()',
+        "Shell command execution — ensure input is sanitized",
+    ),
+    (
+        "injection.sql-concatenation",
+        "HIGH", "MEDIUM",
+        r'(query|sql|execute)\s*\(\s*["\'].*\+|`[^`]*(SELECT|INSERT|UPDATE|DELETE|DROP)[^`]*\$\{',
+        "SQL query built with string concatenation or template literal — SQL injection risk",
+    ),
+
+    # ── XSS ───────────────────────────────────────────────────────────────
+    (
+        "xss.innerhtml",
+        "HIGH", "MEDIUM",
+        r'\binnerHTML\s*=\s*(?!["\']["\'])',
+        "Direct innerHTML assignment — potential XSS if content is user-controlled",
+    ),
+    (
+        "xss.document-write",
+        "MEDIUM", "MEDIUM",
+        r'\bdocument\s*\.\s*write\s*\(',
+        "document.write() can introduce XSS when used with unsanitized input",
+    ),
+    (
+        "xss.dangerously-set-html",
+        "HIGH", "HIGH",
+        r'dangerouslySetInnerHTML',
+        "dangerouslySetInnerHTML bypasses React XSS protection",
+    ),
+
+    # ── Insecure Configurations ────────────────────────────────────────────
+    (
+        "tls.reject-unauthorized-false",
+        "HIGH", "HIGH",
+        r'rejectUnauthorized\s*:\s*false',
+        "TLS certificate verification disabled — vulnerable to MITM attacks",
+    ),
+    (
+        "crypto.weak-hash-md5",
+        "MEDIUM", "HIGH",
+        r'\bcreateHash\s*\(\s*["\']md5["\']\)',
+        "MD5 is a cryptographically broken hash function",
+    ),
+    (
+        "crypto.weak-hash-sha1",
+        "MEDIUM", "HIGH",
+        r'\bcreateHash\s*\(\s*["\']sha1["\']\)',
+        "SHA-1 is a deprecated and weak hash function",
+    ),
+    (
+        "crypto.insecure-random",
+        "MEDIUM", "MEDIUM",
+        r'\bMath\s*\.\s*random\s*\(\)',
+        "Math.random() is not cryptographically secure — use crypto.getRandomValues()",
+    ),
+
+    # ── Hardcoded IPs ─────────────────────────────────────────────────────
+    (
+        "config.hardcoded-ip",
+        "LOW", "MEDIUM",
+        r'["\'](192\.168\.\d{1,3}\.\d{1,3}|10\.\d{1,3}\.\d{1,3}\.\d{1,3})["\']',
+        "Hardcoded private IP address detected",
+    ),
+]
+
+
+def scan(code: str, language: str, scan_id: str) -> Dict[str, Any]:
+    """
+    Scan source code with regex rules.
+    Returns a result dict compatible with result_parser.normalize_result output.
+    """
+    lines = code.splitlines()
+    findings: List[Dict[str, Any]] = []
+    seen: set = set()
+
+    for lineno, line in enumerate(lines, start=1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("//") or stripped.startswith("#"):
+            continue
+
+        for rule_id, severity, confidence, pattern, description in _RULES:
+            flags = 0 if rule_id.startswith("cs:") else re.IGNORECASE
+            clean_id = rule_id[3:] if rule_id.startswith("cs:") else rule_id
+
+            if re.search(pattern, line, flags):
+                key = (clean_id, lineno)
+                if key in seen:
+                    continue
+                seen.add(key)
+
+                snippet = line.rstrip()
+                if len(snippet) > 120:
+                    snippet = snippet[:117] + "..."
+
+                findings.append({
+                    "line":         lineno,
+                    "severity":     severity,
+                    "confidence":   confidence,
+                    "issue":        description,
+                    "code_snippet": snippet,
+                    "rule_id":      clean_id,
+                })
+
+    severity_order = {"HIGH": 0, "MEDIUM": 1, "LOW": 2}
+    findings.sort(key=lambda f: (severity_order.get(f["severity"], 3), f["line"]))
+
+    summary = {"HIGH": 0, "MEDIUM": 0, "LOW": 0}
+    for f in findings:
+        summary[f["severity"]] = summary.get(f["severity"], 0) + 1
+
+    return {
+        "scan_id":    scan_id,
+        "language":   language,
+        "tool":       "pattern",
+        "findings":   findings,
+        "summary":    summary,
+        "vuln_count": len(findings),
+    }

--- a/sast-platform/lambda_b/result_parser.py
+++ b/sast-platform/lambda_b/result_parser.py
@@ -108,6 +108,19 @@ def parse_semgrep_output(raw_output: Dict[str, Any], scan_id: str, language: str
 	}
 
 
+def parse_pattern_output(raw_output: Dict[str, Any], scan_id: str, language: str) -> Dict[str, Any]:
+	findings: List[Dict[str, Any]] = raw_output.get("findings", [])
+	summary: Dict[str, int] = raw_output.get("summary", {"HIGH": 0, "MEDIUM": 0, "LOW": 0})
+	return {
+		"scan_id": scan_id,
+		"language": language,
+		"tool": "pattern",
+		"findings": findings,
+		"summary": summary,
+		"vuln_count": len(findings),
+	}
+
+
 def normalize_result(tool: str, raw_output: Dict[str, Any], scan_id: str, language: str) -> Dict[str, Any]:
 	tool_name = (tool or "").strip().lower()
 
@@ -115,6 +128,8 @@ def normalize_result(tool: str, raw_output: Dict[str, Any], scan_id: str, langua
 		return parse_bandit_output(raw_output or {}, scan_id=scan_id, language=language)
 	if tool_name == "semgrep":
 		return parse_semgrep_output(raw_output or {}, scan_id=scan_id, language=language)
+	if tool_name == "pattern":
+		return parse_pattern_output(raw_output or {}, scan_id=scan_id, language=language)
 
 	raise ValueError(f"Unsupported tool: {tool}")
 

--- a/sast-platform/lambda_b/scanner.py
+++ b/sast-platform/lambda_b/scanner.py
@@ -10,7 +10,22 @@ import sys
 import tempfile
 import logging
 
+import pattern_scanner as _pattern_scanner
+
 logger = logging.getLogger(__name__)
+
+
+def _semgrep_available() -> bool:
+    """Return True if semgrep can be invoked via the current Python executable."""
+    try:
+        result = subprocess.run(
+            [sys.executable, '-m', 'semgrep', '--version'],
+            capture_output=True,
+            timeout=10,
+        )
+        return result.returncode == 0
+    except Exception:
+        return False
 
 # Prefer locally-bundled rules (written into the image at build time) so the
 # container does not need outbound internet access at scan time.  Fall back to
@@ -55,7 +70,14 @@ class SecurityScanner:
                 if language.lower() == 'python':
                     return self._scan_with_bandit(code, scan_id, timeout)
                 elif language.lower() in ['java', 'javascript', 'js', 'typescript', 'go', 'ruby', 'c', 'cpp']:
-                    return self._scan_with_semgrep(code, language, scan_id, timeout)
+                    if _semgrep_available():
+                        return self._scan_with_semgrep(code, language, scan_id, timeout)
+                    logger.info(
+                        "semgrep not available — using built-in pattern scanner for %s (scan_id: %s)",
+                        language, scan_id,
+                    )
+                    result = _pattern_scanner.scan(code, language, scan_id)
+                    return {'scan_id': scan_id, 'language': language, 'tool': 'pattern', 'raw_output': result}
                 else:
                     raise ValueError(f"Unsupported language type: {language}")
 


### PR DESCRIPTION
## Problem

JS/TS scans in Lambda-only deployments return **0 findings** because:
1. `semgrep` (224 MB) cannot be bundled in the Lambda zip (250 MB unzipped limit)
2. `handler.py` still routed JS/TS to ECS even when ECS was not configured (`ecs_configured=False`), causing "Task Definition can not be blank" errors

## Changes

- **`lambda_b/pattern_scanner.py`** (new): Lightweight pure-Python regex scanner with 18 rules covering hardcoded secrets (Stripe, AWS, passwords, connection strings, GitHub tokens, private keys, JWT), dangerous functions (eval, new Function, exec, SQL injection), XSS (innerHTML, document.write, dangerouslySetInnerHTML), insecure TLS, weak crypto (MD5, SHA1, Math.random), and hardcoded IPs
- **`lambda_b/scanner.py`**: Added `_semgrep_available()` runtime check; falls back to `pattern_scanner` when semgrep is not installed
- **`lambda_b/result_parser.py`**: Added `parse_pattern_output()` and updated `normalize_result()` to handle `tool="pattern"`
- **`lambda_b/handler.py`**: Fixed second ECS routing check — `needs_ecs` now guarded by `ecs_configured` to prevent routing to ECS when it is not deployed

## Test plan

- [ ] Deploy in Lambda-only mode (no `--vpc-id`) and submit a JS file — should get findings from pattern scanner
- [ ] Deploy with ECS enabled — JS scan should still route to ECS (semgrep)
- [ ] Python scan unaffected (uses bandit)
- [ ] Verify `tool` field in scan result is `"pattern"` for Lambda-only JS scans

🤖 Generated with [Claude Code](https://claude.com/claude-code)