### PR TITLE
fix: style Refresh link button in report download section

### DIFF
--- a/sast-platform/frontend/css/style.css
+++ b/sast-platform/frontend/css/style.css
@@ -984,6 +984,29 @@ body {
 
 .url-expired { color: var(--red); }
 
+#refresh-url-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  margin-left: auto;
+  padding: 4px 12px;
+  background: none;
+  border: 1.5px solid var(--border);
+  border-radius: 20px;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: color .15s, border-color .15s, background .15s;
+}
+#refresh-url-btn::before { content: "↻"; font-size: 14px; }
+#refresh-url-btn:hover:not(:disabled) {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: rgba(var(--accent-rgb), .06);
+}
+#refresh-url-btn:disabled { opacity: .4; cursor: not-allowed; }
+
 /* ── History view ── */
 .history-view-panel {
   flex: 1;


### PR DESCRIPTION
## Summary
- "Refresh link" button was an unstyled default browser button (looked like a plain `<button>`)
- Now styled as a pill-shaped icon button consistent with the existing design system
- Uses `↻` prefix icon, muted text colour at rest, accent colour on hover with subtle background fill
- `margin-left: auto` keeps it right-aligned next to the expiry text

## Test plan
- [ ] View a completed scan report — Refresh link button should appear as a styled pill button
- [ ] Hover over the button — should change to accent colour
- [ ] Click the button — should refresh the presigned download URL as before
- [ ] Works correctly across all colour themes (green / pink / yellow / blue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)