### PR TITLE
fix: reset progress bar and status on validation failure and Clear

### DIFF
--- a/sast-platform/frontend/js/app.js
+++ b/sast-platform/frontend/js/app.js
@@ -178,8 +178,8 @@ async function handleSubmit() {
 
   dismissError();
 
-  if (!language) { showError("Please select a language."); return; }
-  if (!code)     { showError("Please paste some code to scan."); return; }
+  if (!language) { progressReset(); resetStatus(); showError("Please select a language."); return; }
+  if (!code)     { progressReset(); resetStatus(); showError("Please paste some code to scan."); return; }
 
   setSubmitLoading(true);
   resetStatus();
@@ -689,6 +689,13 @@ function clearCode() {
   document.getElementById("code").value = "";
   updateCodeStats();
   document.getElementById("code").focus();
+
+  if (_pollTimer) { clearTimeout(_pollTimer); _pollTimer = null; }
+  _currentScanId = null;
+  progressReset();
+  resetStatus();
+  setSubmitLoading(false);
+  dismissError();
 }
 
 // ── KPI animation ────────────────────────────────────────────────────────────
@@ -755,6 +762,13 @@ function progressFail() {
     wrap.classList.add("hidden");
     bar.style.width = "0%";
   }, 800);
+}
+
+function progressReset() {
+  if (_progressTimer) { clearTimeout(_progressTimer); _progressTimer = null; }
+  const wrap = document.getElementById("scan-progress-wrap");
+  const bar  = document.getElementById("scan-progress-bar");
+  if (wrap) { wrap.classList.add("hidden"); bar.style.width = "0%"; bar.style.background = "var(--accent)"; }
 }
 
 // ── Dark mode ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Clicking **Scan Code** with empty code or no language selected now resets the previous scan's progress bar and failed-status badge before showing the validation error
- **Clear** button performs a full reset: stops poll timer, hides progress bar, resets status indicators, restores submit button, dismisses error banner
- Extracted `progressReset()` helper to avoid duplicated inline reset logic

## Test plan
- [ ] Complete a scan, then clear the code input and click Scan Code — previous progress/status bar disappears, error message appears
- [ ] Complete a scan, upload an empty file, click Scan Code — same behavior
- [ ] Click Clear mid-scan — polling stops and UI fully resets
- [ ] Normal scan flow unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)