### PR TITLE
fix: dismiss error banner when navigating away from Scanner

### DIFF
--- a/sast-platform/frontend/js/app.js
+++ b/sast-platform/frontend/js/app.js
@@ -74,6 +74,7 @@ function switchView(name) {
   const titles = { scanner: "Scanner", results: "Results", history: "History" };
   if (title) title.textContent = titles[name] || name;
 
+  if (name !== "scanner") dismissError();
   if (name === "results" && !_currentReport) setResultsEmptyState(true);
   if (name === "history") loadHistory();
 }


### PR DESCRIPTION
## Summary
- Error messages like "Please paste some code to scan." now auto-dismiss when the user navigates to Results or History
- One-line fix in `switchView()`: calls `dismissError()` whenever leaving the Scanner view

## Test plan
- [ ] Trigger a validation error in Scanner (e.g. click Scan Code with empty input)
- [ ] Click History or Results — error banner should disappear
- [ ] Navigate back to Scanner — no stale error shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)