### PR TITLE
fix: non-Python scans fail when ECS not configured (Task Definition blank)

### DIFF
--- a/sast-platform/lambda_b/handler.py
+++ b/sast-platform/lambda_b/handler.py
@@ -236,17 +236,11 @@ def process_scan_request(scan_id: str, language: str, student_id: str,
         logger.info(f"Fetching code from S3 - scan_id: {scan_id}, key: {s3_code_key}")
         code = _fetch_code_from_s3(s3_bucket_name, s3_code_key)
 
-        # Route large Python submissions to ECS to avoid Lambda timeout/OOM.
+        # Route oversized submissions to ECS to avoid Lambda timeout/OOM.
+        # Non-Python language routing was already handled above (ECS only when configured).
         code_bytes = len(code.encode('utf-8'))
-        semgrep_languages = {'java', 'javascript', 'typescript', 'go', 'ruby', 'c', 'cpp'}
-        needs_ecs = (code_bytes > LAMBDA_CODE_SIZE_LIMIT) or (language.lower() in semgrep_languages)
-        if needs_ecs:
-            reason = (
-                f"code size {code_bytes} bytes exceeds {LAMBDA_CODE_SIZE_LIMIT} limit"
-                if code_bytes > LAMBDA_CODE_SIZE_LIMIT
-                else f"language '{language}' requires Semgrep (not available in Lambda)"
-            )
-            logger.info(f"Routing to ECS Fargate ({reason}) - scan_id: {scan_id}")
+        if code_bytes > LAMBDA_CODE_SIZE_LIMIT and ecs_configured:
+            logger.info(f"Routing to ECS Fargate (code size {code_bytes} bytes exceeds {LAMBDA_CODE_SIZE_LIMIT} limit) - scan_id: {scan_id}")
             update_scan_status(table, student_id, scan_id, 'ECS_QUEUED')
             ecs_result = handle_ecs_fallback(scan_id, language, student_id, s3_code_key)
             if not ecs_result['success']:


### PR DESCRIPTION
## Problem
JS/TS/Java/Go/Ruby/C/C++ scans always failed with:
```
ECS task launch failed: Task Definition can not be blank.
```
even though ECS was intentionally not deployed (no VPC configured).

## Root Cause
`handler.py` had two separate ECS-routing blocks for non-Python languages:

1. **First block** (correct): checks `ecs_configured` → routes to ECS only when configured, otherwise logs "running inline" and falls through
2. **Second block** (bug): `needs_ecs` unconditionally included all semgrep languages, overriding the first block and always attempting ECS — ignoring whether it was configured

This meant `scanner.py`'s inline `teacher_scanner` / semgrep path was never reachable for JS/TS.

## Fix
The second block now only routes to ECS for **oversized submissions** (`code_bytes > LAMBDA_CODE_SIZE_LIMIT`) **and** only when `ecs_configured` is true. Non-Python language routing is fully handled by the first block.

## Test plan
- [ ] Scan JavaScript code without ECS configured — should succeed using `teacher_scanner`
- [ ] Scan Python code — still uses Bandit inline, unaffected
- [ ] Oversized submissions (>250 KB) still route to ECS when configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)