### PR TITLE
Fix needs_ecs routing when ECS is not configured

### DIFF
--- a/sast-platform/lambda_b/handler.py
+++ b/sast-platform/lambda_b/handler.py
@@ -239,12 +239,12 @@ def process_scan_request(scan_id: str, language: str, student_id: str,
         # Route large Python submissions to ECS to avoid Lambda timeout/OOM.
         code_bytes = len(code.encode('utf-8'))
         semgrep_languages = {'java', 'javascript', 'typescript', 'go', 'ruby', 'c', 'cpp'}
-        needs_ecs = (code_bytes > LAMBDA_CODE_SIZE_LIMIT) or (language.lower() in semgrep_languages)
+        needs_ecs = (code_bytes > LAMBDA_CODE_SIZE_LIMIT) or (language.lower() in semgrep_languages and ecs_configured)
         if needs_ecs:
             reason = (
                 f"code size {code_bytes} bytes exceeds {LAMBDA_CODE_SIZE_LIMIT} limit"
                 if code_bytes > LAMBDA_CODE_SIZE_LIMIT
-                else f"language '{language}' requires Semgrep (not available in Lambda)"
+                else f"language '{language}' requires Semgrep — routing to ECS Fargate"
             )
             logger.info(f"Routing to ECS Fargate ({reason}) - scan_id: {scan_id}")
             update_scan_status(table, student_id, scan_id, 'ECS_QUEUED')


### PR DESCRIPTION
Stage 2 needs_ecs check was unconditionally routing semgrep languages to ECS even when ecs_configured=False, causing failures for teammates without ECS environment variables set. Added ecs_configured guard to the language-based condition so non-ECS deployments fall through to inline scanning.