### PR TITLE
remove: drop C and C++ language support

### DIFF
--- a/sast-platform/frontend/index.html
+++ b/sast-platform/frontend/index.html
@@ -113,8 +113,6 @@
               <option value="typescript">TypeScript</option>
               <option value="go">Go</option>
               <option value="ruby">Ruby</option>
-              <option value="c">C</option>
-              <option value="cpp">C++</option>
             </select>
           </div>
 

--- a/sast-platform/frontend/js/app.js
+++ b/sast-platform/frontend/js/app.js
@@ -32,10 +32,6 @@ const EXT_TO_LANGUAGE = {
   ts:   "typescript",
   go:   "go",
   rb:   "ruby",
-  c:    "c",
-  cpp:  "cpp",
-  cc:   "cpp",
-  cxx:  "cpp",
 };
 
 let _currentScanId   = null;

--- a/sast-platform/lambda_b/handler.py
+++ b/sast-platform/lambda_b/handler.py
@@ -209,7 +209,7 @@ def process_scan_request(scan_id: str, language: str, student_id: str,
         # Route to ECS Fargate only when ECS is configured (VPC deployment).
         # When ECS is not configured, semgrep runs directly inside Lambda
         # (semgrep is bundled in requirements.txt and invoked via python -m semgrep).
-        SEMGREP_LANGUAGES = {'java', 'javascript', 'js', 'typescript', 'go', 'ruby', 'c', 'cpp'}
+        SEMGREP_LANGUAGES = {'java', 'javascript', 'js', 'typescript', 'go', 'ruby'}
         ecs_configured = bool(
             os.environ.get('ECS_CLUSTER_NAME', '').strip() and
             os.environ.get('ECS_TASK_DEFINITION', '').strip()

--- a/sast-platform/lambda_b/scanner.py
+++ b/sast-platform/lambda_b/scanner.py
@@ -58,7 +58,7 @@ class SecurityScanner:
                 elif language.lower() in ['javascript', 'js', 'typescript']:
                     # Use teacher's Node.js scanner for JS/TS (as required by course)
                     return self._scan_with_teacher_scanner(code, language, scan_id, timeout)
-                elif language.lower() in ['java', 'go', 'ruby', 'c', 'cpp']:
+                elif language.lower() in ['java', 'go', 'ruby']:
                     return self._scan_with_semgrep(code, language, scan_id, timeout)
                 else:
                     raise ValueError(f"Unsupported language type: {language}")

--- a/sast-platform/test-samples/code/vuln_ruby.rb
+++ b/sast-platform/test-samples/code/vuln_ruby.rb
@@ -1,0 +1,33 @@
+# vuln_ruby.rb — intentionally vulnerable Ruby for scanner testing.
+
+# Hardcoded credentials
+DB_PASSWORD = "supersecret123"
+API_KEY = "sk-hardcoded-api-key-abc123456"
+
+# Command injection via eval
+def run_code(user_input)
+  eval(user_input)
+end
+
+# SQL injection via string interpolation
+def get_user(username)
+  query = "SELECT * FROM users WHERE name='#{username}'"
+  db.execute(query)
+end
+
+# Shell injection
+def list_files(path)
+  system("ls " + path)
+end
+
+# Weak hash (MD5)
+require 'digest'
+def hash_password(password)
+  Digest::MD5.hexdigest(password)
+end
+
+# Hardcoded secret in URL
+def connect_db
+  url = "postgres://admin:password123@localhost/mydb"
+  url
+end

--- a/sast-platform/test-samples/code/vuln_typescript.ts
+++ b/sast-platform/test-samples/code/vuln_typescript.ts
@@ -1,0 +1,36 @@
+// vuln_typescript.ts — intentionally vulnerable TypeScript for scanner testing.
+
+const API_KEY = "sk-hardcoded-secret-token-abc123";
+const DB_PASSWORD = "supersecret123";
+
+// XSS via innerHTML
+function renderMessage(msg: string): void {
+    document.getElementById("output")!.innerHTML = msg;
+}
+
+// eval injection
+function calculate(expr: string): any {
+    return eval(expr);
+}
+
+// document.write XSS
+function greet(username: string): void {
+    document.write("<h1>Welcome, " + username + "</h1>");
+}
+
+// SQL injection via string concatenation
+async function getUser(username: string): Promise<any> {
+    const query = `SELECT * FROM users WHERE name='${username}'`;
+    return db.execute(query);
+}
+
+// Insecure random for token
+function generateToken(): string {
+    return Math.random().toString(36).substring(2);
+}
+
+// Weak crypto
+import * as crypto from "crypto";
+function hashPassword(password: string): string {
+    return crypto.createHash("md5").update(password).digest("hex");
+}

--- a/sast-platform/tests/unit/test_scanner.py
+++ b/sast-platform/tests/unit/test_scanner.py
@@ -113,12 +113,6 @@ class TestNewLanguageRouting(unittest.TestCase):
     def test_ruby_routes_to_semgrep_with_rb_extension(self):
         self._assert_semgrep_ext("ruby", ".rb")
 
-    def test_c_routes_to_semgrep_with_c_extension(self):
-        self._assert_semgrep_ext("c", ".c")
-
-    def test_cpp_routes_to_semgrep_with_cpp_extension(self):
-        self._assert_semgrep_ext("cpp", ".cpp")
-
     def test_typescript_case_insensitive(self):
         with patch("scanner.subprocess.run", return_value=_mock_run(stdout="[]")) as mock_run:
             result = SecurityScanner().scan_code("// code", "TypeScript", "sid")


### PR DESCRIPTION
## Summary

- C and C++ scans produced no findings in testing — removed to avoid confusing users
- Removed from frontend language dropdown (`index.html`)
- Removed file extension mappings (`.c`, `.cpp`, `.cc`, `.cxx`) from `app.js`
- Removed `c` and `cpp` from backend routing sets in `handler.py` and `scanner.py`

## Also included

- Fix execute permission on `04_build_ecs_image.sh`
- Add Ruby and TypeScript test sample files under `test-samples/code/`

Replaces #123 (conflict resolved via rebase onto main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)