### PR TITLE
fix: correct ECS task definition image URI on deploy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -49,6 +49,7 @@ jobs:
               - 'sast-platform/frontend/**'
             infra:
               - 'sast-platform/infrastructure/**'
+              - 'sast-platform/scripts/01_setup_infra.sh'
 
   # ── 3. CloudFormation stacks (only when infrastructure yaml files change) ──
   deploy-infra:

--- a/sast-platform/scripts/01_setup_infra.sh
+++ b/sast-platform/scripts/01_setup_infra.sh
@@ -225,7 +225,8 @@ ECS_CLUSTER_NAME=""
 ECS_TASK_DEF_ARN=""
 
 if [[ -n "$VPC_ID" ]]; then
-  DEFAULT_IMAGE="${PROJECT_NAME}.dkr.ecr.${AWS_REGION}.amazonaws.com/sast-scanner:latest"
+  _ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
+  DEFAULT_IMAGE="${_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${PROJECT_NAME}-${ENVIRONMENT}-scanner:latest"
   SCANNER_IMAGE="${SCANNER_IMAGE:-$DEFAULT_IMAGE}"
 
   deploy_stack "$STACK_ECS" "$INFRA_DIR/ecs.yaml" \

--- a/sast-platform/scripts/04_build_ecs_image.sh
+++ b/sast-platform/scripts/04_build_ecs_image.sh
@@ -203,16 +203,30 @@ cleanup_local_images() {
     echo -e "${GREEN}Cleanup complete${NC}"
 }
 
+update_ecs_task_definition() {
+    local stack_name="${PROJECT_NAME}-${ENVIRONMENT}-ecs"
+
+    if ! aws cloudformation describe-stacks \
+            --stack-name "$stack_name" --region "$AWS_REGION" &>/dev/null; then
+        echo "ECS CloudFormation stack '$stack_name' not found — skipping task definition update"
+        return 0
+    fi
+
+    echo -e "${YELLOW}Updating ECS task definition with new image URI...${NC}"
+    aws cloudformation deploy \
+        --stack-name "$stack_name" \
+        --region "$AWS_REGION" \
+        --use-previous-template \
+        --parameter-overrides "ScannerImageUri=${ECR_URI}:${IMAGE_TAG}" \
+        --no-fail-on-empty-changeset \
+        --capabilities CAPABILITY_IAM
+    echo -e "${GREEN}ECS task definition updated → ${ECR_URI}:${IMAGE_TAG}${NC}"
+}
+
 show_deployment_info() {
     echo
     echo -e "${GREEN}=== Image Info ===${NC}"
     echo -e "ECR URI: ${GREEN}$ECR_URI:$IMAGE_TAG${NC}"
-    echo -e "Image size: $(docker images "$ECR_URI:$IMAGE_TAG" --format "{{.Size}}")"
-    echo
-    echo "Next steps:"
-    echo "1. Update the ECS task definition image URI"
-    echo "2. Set the ECS_TASK_DEFINITION environment variable in Lambda B"
-    echo "3. Ensure the ECS service has permission to pull from ECR"
     echo
     echo "Local test command:"
     echo "docker run --rm -e SCAN_ID=test -e STUDENT_ID=test -e LANGUAGE=python -e CODE_CONTENT='print(\"hello\")' $ECR_URI:$IMAGE_TAG"
@@ -232,6 +246,7 @@ main() {
     fi
 
     push_docker_image
+    update_ecs_task_definition
     cleanup_local_images
     show_deployment_info
 


### PR DESCRIPTION
## Root cause

All non-Python ECS scans (JavaScript, Java, Go, Ruby) were failing with a container pull error. Two bugs:

### Bug 1 — `01_setup_infra.sh`: wrong default image URI

The default `ScannerImageUri` passed to CloudFormation was:
```
${PROJECT_NAME}.dkr.ecr.${AWS_REGION}.amazonaws.com/sast-scanner:latest
```
This is missing the **AWS account ID** and uses the wrong repo name (`sast-scanner` instead of `sast-platform-dev-scanner`). ECS could never pull the image.

**Fix**: derive `DEFAULT_IMAGE` from `aws sts get-caller-identity` at deploy time:
```bash
_ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
DEFAULT_IMAGE="${_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${PROJECT_NAME}-${ENVIRONMENT}-scanner:latest"
```

### Bug 2 — `04_build_ecs_image.sh`: task definition never updated after image push

After pushing a new image to ECR the CloudFormation ECS stack was never updated, so the task definition kept pointing to the old placeholder URI.

**Fix**: after every `docker push`, update the CloudFormation stack:
```bash
aws cloudformation deploy \
    --stack-name "${PROJECT_NAME}-${ENVIRONMENT}-ecs" \
    --use-previous-template \
    --parameter-overrides "ScannerImageUri=${ECR_URI}:${IMAGE_TAG}" \
    --no-fail-on-empty-changeset
```

### Also
- Added `scripts/01_setup_infra.sh` to the CD `infra` paths-filter so changes to the script trigger a CloudFormation re-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)