### PR TITLE
chore: trigger build-ecs to update ECS task definition

### DIFF
--- a/sast-platform/lambda_b/handler.py
+++ b/sast-platform/lambda_b/handler.py
@@ -3,6 +3,7 @@ Lambda B Main Handler
 Responsibilities:
 1. Extract scan task information from SQS messages
 2. Call scanning engine for code security analysis
+
 3. Parse and standardize scan results
 4. Write results to S3 and update DynamoDB status
 """


### PR DESCRIPTION
## Summary

- The previous PR #126 fixed the logic in `04_build_ecs_image.sh` and `01_setup_infra.sh`, but the `deploy-infra` job skips CloudFormation stacks that already exist in a healthy state
- The ECS stack was originally created with a wrong `ScannerImageUri` (missing account ID) and was never updated
- This trivial `lambda_b` change triggers the `build-ecs` CD job, which will:
  1. Build and push the Docker image with the correct ECR URI
  2. Call `update_ecs_task_definition()` to update the ECS CloudFormation stack with the correct image URI

## Test plan
- [ ] Merge this PR → CD runs `build-ecs` job
- [ ] After CD completes, submit a JavaScript scan — it should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)