### PR TITLE
fix: include scanner.js files in Lambda B CD packaging

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -106,6 +106,9 @@ jobs:
           mkdir -p /tmp/lambda_b_build
           cp sast-platform/lambda_b/*.py /tmp/lambda_b_build/
           cp sast-platform/lambda_b/requirements.txt /tmp/lambda_b_build/
+          cp sast-platform/lambda_b/scanner.js      /tmp/lambda_b_build/ 2>/dev/null || true
+          cp sast-platform/lambda_b/run_scanner.mjs /tmp/lambda_b_build/ 2>/dev/null || true
+          cp sast-platform/lambda_b/package.json    /tmp/lambda_b_build/ 2>/dev/null || true
           rm -f /tmp/lambda_b_build/ecs_handler.py
           python3 -m pip install --target /tmp/lambda_b_build \
             -r /tmp/lambda_b_build/requirements.txt --quiet --upgrade


### PR DESCRIPTION
## Summary

- Adds `scanner.js`, `run_scanner.mjs`, and `package.json` to the Lambda B zip during `deploy-infra`
- Previously only `*.py` files were copied, so the teacher's Node.js scanner was missing in non-ECS (inline) deployments
- Resolves the conflict-free version of beibei-ui's PR #128

## Why no conflict?
PR #128 tried to add a full new `cd.yml` from an older base — conflict with our existing `cd.yml`. This PR applies only the 3 relevant `cp` lines to the current file.

## Test plan
- [ ] Merge → CD runs `deploy-infra` on next infra change, Lambda B zip will include JS scanner files
- [ ] JS/TS scans work in both ECS and Lambda-inline modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)