### PR TITLE
fix: update Lambda B ECS_TASK_DEFINITION to family name after image build

### DIFF
--- a/sast-platform/scripts/04_build_ecs_image.sh
+++ b/sast-platform/scripts/04_build_ecs_image.sh
@@ -223,6 +223,41 @@ update_ecs_task_definition() {
     echo -e "${GREEN}ECS task definition updated → ${ECR_URI}:${IMAGE_TAG}${NC}"
 }
 
+# After updating the ECS stack (which creates a new task definition revision),
+# point Lambda B to the task definition FAMILY NAME instead of a specific revision ARN.
+# Using the family name means ECS always picks the latest active revision automatically,
+# so future image rebuilds take effect without needing to redeploy Lambda B.
+update_lambda_b_task_def_env() {
+    local lambda_func="${PROJECT_NAME}-${ENVIRONMENT}-scanner"
+    local task_def_family="${PROJECT_NAME}-${ENVIRONMENT}-scanner"
+
+    echo -e "${YELLOW}Updating Lambda B ECS_TASK_DEFINITION → family name...${NC}"
+
+    # Fetch all current env vars so we don't clobber them
+    local current_env
+    current_env=$(aws lambda get-function-configuration \
+        --function-name "$lambda_func" \
+        --region "$AWS_REGION" \
+        --query 'Environment.Variables' \
+        --output json 2>/dev/null || echo '{}')
+
+    # Merge: replace only ECS_TASK_DEFINITION
+    local new_env
+    new_env=$(python3 -c "
+import json, sys
+env = json.loads('''$current_env''')
+env['ECS_TASK_DEFINITION'] = '$task_def_family'
+print(json.dumps({'Variables': env}))
+")
+
+    aws lambda update-function-configuration \
+        --function-name "$lambda_func" \
+        --region "$AWS_REGION" \
+        --environment "$new_env" > /dev/null
+
+    echo -e "${GREEN}Lambda B ECS_TASK_DEFINITION = $task_def_family (always latest revision)${NC}"
+}
+
 show_deployment_info() {
     echo
     echo -e "${GREEN}=== Image Info ===${NC}"
@@ -247,6 +282,7 @@ main() {
 
     push_docker_image
     update_ecs_task_definition
+    update_lambda_b_task_def_env
     cleanup_local_images
     show_deployment_info
 


### PR DESCRIPTION
## Root cause

Lambda B's `ECS_TASK_DEFINITION` env var was set to a **specific revision ARN** (e.g. `arn:...:task-definition/sast-platform-dev-scanner:1`) at initial CloudFormation deployment.

When `04_build_ecs_image.sh` updated the ECS CloudFormation stack with the correct image URI, it created **revision :2** — but Lambda B still launched ECS tasks using **revision :1** (wrong image URI → `CannotPullContainerError` → scan fails).

This is why `build-ecs` showed green but JS scans kept failing.

## Fix

After each image build, call `aws lambda update-function-configuration` to update Lambda B's `ECS_TASK_DEFINITION` env var to the **task definition family name** (without revision suffix).

ECS's `run_task` API accepts a family name and automatically uses the **latest active revision**, so future image rebuilds take effect without redeploying Lambda B.

## Test plan
- [ ] Merge → CD triggers `build-ecs` (lambda_b path changed via this script)
- [ ] After CD completes, Lambda B `ECS_TASK_DEFINITION` env var = `sast-platform-dev-scanner`
- [ ] Submit a JavaScript scan → should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)