### PR TITLE
fix: add 04_build_ecs_image.sh to lambda_b path filter and trigger build-ecs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,6 +45,7 @@ jobs:
               - 'sast-platform/lambda_a/**'
             lambda_b:
               - 'sast-platform/lambda_b/**'
+              - 'sast-platform/scripts/04_build_ecs_image.sh'
             frontend:
               - 'sast-platform/frontend/**'
             infra:

--- a/sast-platform/lambda_b/handler.py
+++ b/sast-platform/lambda_b/handler.py
@@ -1,6 +1,7 @@
 """
 Lambda B Main Handler
 Responsibilities:
+
 1. Extract scan task information from SQS messages
 2. Call scanning engine for code security analysis
 


### PR DESCRIPTION
## Problem

PR #130 changed `sast-platform/scripts/04_build_ecs_image.sh` but that path wasn't in any paths filter, so `build-ecs` was skipped and the Lambda B env var fix never ran.

## Changes

1. **cd.yml**: add `sast-platform/scripts/04_build_ecs_image.sh` to the `lambda_b` paths filter — future changes to the ECS build script will now trigger `build-ecs`
2. **handler.py**: trivial whitespace change to trigger `build-ecs` in this CD run, which will execute `update_lambda_b_task_def_env()` and set `ECS_TASK_DEFINITION` to the family name (always uses latest revision)

## Test plan
- [ ] Merge → `build-ecs` runs this time
- [ ] After CD completes, JS scan succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)