### PR TITLE
fix: set ECS_SUBNETS and ECS_SECURITY_GROUPS on Lambda B after image build

### DIFF
--- a/sast-platform/scripts/04_build_ecs_image.sh
+++ b/sast-platform/scripts/04_build_ecs_image.sh
@@ -223,17 +223,40 @@ update_ecs_task_definition() {
     echo -e "${GREEN}ECS task definition updated → ${ECR_URI}:${IMAGE_TAG}${NC}"
 }
 
-# After updating the ECS stack (which creates a new task definition revision),
-# point Lambda B to the task definition FAMILY NAME instead of a specific revision ARN.
-# Using the family name means ECS always picks the latest active revision automatically,
-# so future image rebuilds take effect without needing to redeploy Lambda B.
+# After updating the ECS stack, sync Lambda B's ECS-related env vars so it can
+# actually launch Fargate tasks:
+#   ECS_TASK_DEFINITION  → family name (no revision), always picks latest
+#   ECS_SUBNETS          → default-VPC subnets (auto-detected)
+#   ECS_SECURITY_GROUPS  → security group from the ECS CloudFormation stack
 update_lambda_b_task_def_env() {
     local lambda_func="${PROJECT_NAME}-${ENVIRONMENT}-scanner"
     local task_def_family="${PROJECT_NAME}-${ENVIRONMENT}-scanner"
+    local ecs_stack="${PROJECT_NAME}-${ENVIRONMENT}-ecs"
 
-    echo -e "${YELLOW}Updating Lambda B ECS_TASK_DEFINITION → family name...${NC}"
+    echo -e "${YELLOW}Syncing Lambda B ECS env vars...${NC}"
 
-    # Fetch all current env vars so we don't clobber them
+    # --- Auto-detect default VPC subnets ---
+    local vpc_id subnet_ids sg_id
+    vpc_id=$(aws ec2 describe-vpcs --region "$AWS_REGION" \
+        --filters "Name=isDefault,Values=true" \
+        --query "Vpcs[0].VpcId" --output text 2>/dev/null || true)
+
+    if [[ -n "$vpc_id" && "$vpc_id" != "None" ]]; then
+        subnet_ids=$(aws ec2 describe-subnets --region "$AWS_REGION" \
+            --filters "Name=vpc-id,Values=$vpc_id" "Name=defaultForAz,Values=true" \
+            --query "Subnets[:2].SubnetId" --output text 2>/dev/null \
+            | tr '[:space:]' ',' | sed 's/,$//' || true)
+        echo "Subnets: $subnet_ids"
+    fi
+
+    # --- Get ECS security group from CloudFormation stack output ---
+    sg_id=$(aws cloudformation describe-stacks \
+        --stack-name "$ecs_stack" --region "$AWS_REGION" \
+        --query "Stacks[0].Outputs[?OutputKey=='ECSSecurityGroupId'].OutputValue" \
+        --output text 2>/dev/null || true)
+    echo "Security group: $sg_id"
+
+    # --- Fetch current Lambda B env vars (to avoid clobbering other vars) ---
     local current_env
     current_env=$(aws lambda get-function-configuration \
         --function-name "$lambda_func" \
@@ -241,21 +264,26 @@ update_lambda_b_task_def_env() {
         --query 'Environment.Variables' \
         --output json 2>/dev/null || echo '{}')
 
-    # Merge: replace only ECS_TASK_DEFINITION
+    # --- Merge updates into existing env vars ---
     local new_env
-    new_env=$(python3 -c "
-import json, sys
+    new_env=$(python3 - <<PYEOF
+import json
 env = json.loads('''$current_env''')
 env['ECS_TASK_DEFINITION'] = '$task_def_family'
+if '$subnet_ids':
+    env['ECS_SUBNETS'] = '$subnet_ids'
+if '$sg_id' and '$sg_id' != 'None':
+    env['ECS_SECURITY_GROUPS'] = '$sg_id'
 print(json.dumps({'Variables': env}))
-")
+PYEOF
+)
 
     aws lambda update-function-configuration \
         --function-name "$lambda_func" \
         --region "$AWS_REGION" \
         --environment "$new_env" > /dev/null
 
-    echo -e "${GREEN}Lambda B ECS_TASK_DEFINITION = $task_def_family (always latest revision)${NC}"
+    echo -e "${GREEN}Lambda B synced: task_def=$task_def_family subnets=$subnet_ids sg=$sg_id${NC}"
 }
 
 show_deployment_info() {


### PR DESCRIPTION
## 根本原因

**JS scan 从一开始就一直失败的真正原因：** `01_setup_infra.sh` 部署 Lambda B 时从来没有传 `SubnetIds` 和 `SecurityGroupIds` 参数，导致 Lambda B 的 `ECS_SUBNETS = ''`。

ECS Fargate 任务在 `awsvpc` 模式下必须指定子网，空子网列表会让 `ecs:RunTask` API 直接报错：
> "At least one subnet must be specified"

`handle_ecs_fallback()` 捕获这个异常，返回 `success=False`，Lambda B 把 scan 标记为 FAILED。所有非 Python 语言的 scan 都走 ECS，所以都失败了。

## 修复

扩展 `update_lambda_b_task_def_env()`，在每次 `build-ecs` 运行时自动更新 Lambda B 的三个 ECS 相关 env var：

| 变量 | 值 |
|------|-----|
| `ECS_TASK_DEFINITION` | family name（无 revision，始终用最新版） |
| `ECS_SUBNETS` | 自动检测默认 VPC 的子网 |
| `ECS_SECURITY_GROUPS` | 从 ECS CloudFormation stack output 读取 |

## Test plan
- [ ] Merge → `build-ecs` 触发（`04_build_ecs_image.sh` 在 `lambda_b` filter 里）
- [ ] CD 完成后，Lambda B `ECS_SUBNETS` 有值
- [ ] 提交 JS scan → 应该成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)