### PR TITLE
fix: create ECS stack and sync ECS_CLUSTER_NAME to Lambda B

### DIFF
--- a/sast-platform/scripts/01_setup_infra.sh
+++ b/sast-platform/scripts/01_setup_infra.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # 01_setup_infra.sh — Deploy all CloudFormation stacks in dependency order.
+# Note: ECS stack is created only when --vpc-id is provided.
 #
 # Usage:
 #   ./01_setup_infra.sh [OPTIONS]

--- a/sast-platform/scripts/04_build_ecs_image.sh
+++ b/sast-platform/scripts/04_build_ecs_image.sh
@@ -249,7 +249,14 @@ update_lambda_b_task_def_env() {
         echo "Subnets: $subnet_ids"
     fi
 
-    # --- Get ECS security group from CloudFormation stack output ---
+    # --- Get ECS cluster name + security group from CloudFormation stack output ---
+    local cluster_name
+    cluster_name=$(aws cloudformation describe-stacks \
+        --stack-name "$ecs_stack" --region "$AWS_REGION" \
+        --query "Stacks[0].Outputs[?OutputKey=='ECSClusterName'].OutputValue" \
+        --output text 2>/dev/null || true)
+    echo "Cluster: $cluster_name"
+
     sg_id=$(aws cloudformation describe-stacks \
         --stack-name "$ecs_stack" --region "$AWS_REGION" \
         --query "Stacks[0].Outputs[?OutputKey=='ECSSecurityGroupId'].OutputValue" \
@@ -274,6 +281,8 @@ if '$subnet_ids':
     env['ECS_SUBNETS'] = '$subnet_ids'
 if '$sg_id' and '$sg_id' != 'None':
     env['ECS_SECURITY_GROUPS'] = '$sg_id'
+if '$cluster_name' and '$cluster_name' != 'None':
+    env['ECS_CLUSTER_NAME'] = '$cluster_name'
 print(json.dumps({'Variables': env}))
 PYEOF
 )


### PR DESCRIPTION
## Problem (discovered from build-ecs logs)

```
ECS CloudFormation stack 'sast-platform-dev-ecs' not found — skipping task definition update
Security group: 
```

- The ECS CloudFormation stack never existed → no ECS cluster, no task definition
- `ECS_CLUSTER_NAME` was never set on Lambda B → `ecs_configured = False` OR `RunTask` fails immediately

## Fix

1. **Trivial change to `01_setup_infra.sh`** → triggers `deploy-infra` job → creates the ECS stack for the first time
2. **`04_build_ecs_image.sh`** → extend `update_lambda_b_task_def_env()` to also read `ECSClusterName` from stack output and set it on Lambda B

## CD flow after merge

```
deploy-infra → creates sast-platform-dev-ecs stack (cluster + task definition)
build-ecs    → builds/pushes image + sets all 4 env vars on Lambda B:
                 ECS_CLUSTER_NAME, ECS_TASK_DEFINITION, ECS_SUBNETS, ECS_SECURITY_GROUPS
```

## Test plan
- [ ] Merge → both deploy-infra and build-ecs run
- [ ] build-ecs log shows "Cluster: sast-platform-dev-scanner-cluster"
- [ ] JS scan submission succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)