### PR TITLE
fix: correct ECS stack name in 04_build_ecs_image.sh

### DIFF
--- a/sast-platform/scripts/04_build_ecs_image.sh
+++ b/sast-platform/scripts/04_build_ecs_image.sh
@@ -204,7 +204,7 @@ cleanup_local_images() {
 }
 
 update_ecs_task_definition() {
-    local stack_name="${PROJECT_NAME}-${ENVIRONMENT}-ecs"
+    local stack_name="${PROJECT_NAME}-ecs"
 
     if ! aws cloudformation describe-stacks \
             --stack-name "$stack_name" --region "$AWS_REGION" &>/dev/null; then
@@ -231,7 +231,7 @@ update_ecs_task_definition() {
 update_lambda_b_task_def_env() {
     local lambda_func="${PROJECT_NAME}-${ENVIRONMENT}-scanner"
     local task_def_family="${PROJECT_NAME}-${ENVIRONMENT}-scanner"
-    local ecs_stack="${PROJECT_NAME}-${ENVIRONMENT}-ecs"
+    local ecs_stack="${PROJECT_NAME}-ecs"
 
     echo -e "${YELLOW}Syncing Lambda B ECS env vars...${NC}"
 


### PR DESCRIPTION
## Problem

`01_setup_infra.sh` creates the ECS stack as **`sast-platform-ecs`**, but `04_build_ecs_image.sh` was looking for **`sast-platform-dev-ecs`** (extra `-dev` segment).

Confirmed in the PR #133 CD run logs:
```
Stack already deployed (UPDATE_COMPLETE): sast-platform-ecs     ← actual name
ECS CloudFormation stack 'sast-platform-dev-ecs' not found      ← what the script searched for
Cluster: 
Security group: 
```

Because the stack was never found, `update_lambda_b_task_def_env()` always set `ECS_CLUSTER_NAME = ""` and `ECS_SECURITY_GROUPS = ""` on Lambda B → `ecs_configured = False` OR `RunTask` validation error → every JS scan returned "Scan failed".

## Fix

Remove the extra `-${ENVIRONMENT}` from the two local variables in `04_build_ecs_image.sh`:

```bash
# Before
local stack_name="${PROJECT_NAME}-${ENVIRONMENT}-ecs"   # sast-platform-dev-ecs ❌
local ecs_stack="${PROJECT_NAME}-${ENVIRONMENT}-ecs"    # sast-platform-dev-ecs ❌

# After
local stack_name="${PROJECT_NAME}-ecs"                  # sast-platform-ecs ✅
local ecs_stack="${PROJECT_NAME}-ecs"                   # sast-platform-ecs ✅
```

## Test plan
- [ ] Merge → build-ecs runs
- [ ] build-ecs log shows `Cluster: sast-platform-dev-cluster` and `Security group: sg-xxx` (non-empty)
- [ ] JS scan succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)