### PR TITLE
fix: reset language selector to default on Clear

### DIFF
--- a/sast-platform/frontend/js/app.js
+++ b/sast-platform/frontend/js/app.js
@@ -688,6 +688,7 @@ function updateCodeStats() {
 
 function clearCode() {
   document.getElementById("code").value = "";
+  document.getElementById("language").value = "";
   updateCodeStats();
   document.getElementById("code").focus();
 


### PR DESCRIPTION
## Summary
- After clicking Clear, the language dropdown now resets back to `— select language —` instead of retaining the previously auto-detected language
- One-line fix in `clearCode()`: added `document.getElementById("language").value = "";`

## Test plan
- [ ] Upload a file (e.g. `.rb`) — language auto-selects as Ruby
- [ ] Click **Clear**
- [ ] Verify the language dropdown shows `— select language —`

🤖 Generated with [Claude Code](https://claude.com/claude-code)