### PR TITLE
fix: display teacher_scanner tool as JS/TS in results view

### DIFF
--- a/sast-platform/frontend/js/results.js
+++ b/sast-platform/frontend/js/results.js
@@ -107,7 +107,9 @@ function renderScanResults(report, target = "results") {
 	const summary   = normalizeSummary(report?.summary || {});
 	const vulnCount = Number(report?.vuln_count ?? findings.length);
 	const scanId    = escapeHtml(report?.scan_id || "-");
-	const tool      = escapeHtml(report?.tool || "-");
+	const TOOL_DISPLAY_NAMES = { teacher_scanner: "JS/TS" };
+	const rawTool   = report?.tool || "-";
+	const tool      = escapeHtml(TOOL_DISPLAY_NAMES[rawTool] || rawTool);
 	const language  = escapeHtml(report?.language || "-");
 
 	const rows = findings


### PR DESCRIPTION
## Problem

The results page shows `teacher_scanner` as the tool name for JavaScript/TypeScript scans, which is an internal implementation detail not meaningful to students.

## Fix

Added a display name mapping in `results.js`:

```js
const TOOL_DISPLAY_NAMES = { teacher_scanner: "JS/TS" };
const rawTool = report?.tool || "-";
const tool    = escapeHtml(TOOL_DISPLAY_NAMES[rawTool] || rawTool);
```

`teacher_scanner` → displays as **JS/TS**. Other tool names (`bandit`, `semgrep`) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)