### PR TITLE
docs: remove C/C++ from supported languages description

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **CS6620 Group 9** | Jingsi (Jess) Zhang · Mengshan (Sunny) Li · Jiahua (Liz) Wu
 
-A serverless static analysis platform on AWS. Students submit source code via a web UI; the system scans it asynchronously using Bandit (Python) and Semgrep (Java / JavaScript / TypeScript / Go / Ruby / C / C++), stores the report in S3, and returns a presigned download URL to the browser.
+A serverless static analysis platform on AWS. Students submit source code via a web UI; the system scans it asynchronously using Bandit (Python) and Semgrep (Java / JavaScript / TypeScript / Go / Ruby), stores the report in S3, and returns a presigned download URL to the browser.
 
 ---
 


### PR DESCRIPTION
Remove '/ C / C++' from the description line in README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)