### PR TITLE
fix: correct comments in scanner.py

### DIFF
--- a/sast-platform/lambda_b/scanner.py
+++ b/sast-platform/lambda_b/scanner.py
@@ -1,8 +1,8 @@
 """
 this module runs security scans on code
 python -> bandit
-javascript/typescript -> teacher's scanner.js (extended with additional semgrep rules)
-java/go/ruby/c/cpp -> semgrep
+javascript/typescript -> teacher's scanner.js (falls back to semgrep if Node.js unavailable)
+java/go/ruby -> semgrep
 """
 import json
 import os
@@ -48,7 +48,7 @@ class SecurityScanner:
         decide which tool to use based on language
         """
         try:
-            # create a temp folder to store code file；will be cleaned up after scan
+            # create a temp folder to store code file; will be cleaned up after scan
             with tempfile.TemporaryDirectory() as temp_dir:
                 self.temp_dir = temp_dir
 
@@ -200,7 +200,7 @@ class SecurityScanner:
 
     def _scan_with_semgrep(self, code: str, language: str, scan_id: str, timeout: int = 300):
         """
-        use semgrep for java / go / ruby / c / cpp
+        use semgrep for java / go / ruby
         """
         logger.info("starting semgrep scan %s (config: %s)", scan_id, _SEMGREP_CONFIG)
 


### PR DESCRIPTION
## Changes

Four comment fixes in `lambda_b/scanner.py`:

1. **Module docstring** — removed `c/cpp` (not routed in `scan_code`); fixed JS/TS description from "extended with additional semgrep rules" to "falls back to semgrep if Node.js unavailable"
2. **`_scan_with_semgrep` docstring** — removed `c / cpp` to match actual routing logic
3. **Chinese semicolon** — `；` → `;` in inline comment

No logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)