### PR TITLE
fix: correct inaccurate comments in Lambda B

### DIFF
--- a/sast-platform/lambda_b/ecs_handler.py
+++ b/sast-platform/lambda_b/ecs_handler.py
@@ -41,7 +41,7 @@ def _fetch_code(s3_bucket_name: str) -> str:
 
     Priority:
     1. S3_CODE_KEY env var — code was uploaded to S3 (S3-staging path, issue #14).
-       Preferred for large submissions because env vars are limited to ~32 KB.
+       Preferred for large submissions because ECS container env var overrides are capped at ~8 KB.
     2. CODE_CONTENT env var — code passed inline (legacy / small submissions).
     """
     s3_code_key = os.environ.get("S3_CODE_KEY")

--- a/sast-platform/lambda_b/handler.py
+++ b/sast-platform/lambda_b/handler.py
@@ -207,7 +207,7 @@ def process_scan_request(scan_id: str, language: str, student_id: str,
                 return {"success": True, "scan_id": scan_id, "skipped": True}
             raise
 
-        # Non-Python languages (Java, JS, TS, Go, Ruby, C, C++) can use Semgrep.
+        # Non-Python languages (Java, JS, TS, Go, Ruby) can use Semgrep.
         # Route to ECS Fargate only when ECS is configured (VPC deployment).
         # When ECS is not configured, semgrep runs directly inside Lambda
         # (semgrep is bundled in requirements.txt and invoked via python -m semgrep).


### PR DESCRIPTION
## Changes

Two comment fixes in Lambda B, no logic changes.

**handler.py**
- `# Non-Python languages (Java, JS, TS, Go, Ruby, C, C++) can use Semgrep.` -> removed `C, C++` since neither is in `SEMGREP_LANGUAGES`

**ecs_handler.py**
- `env vars are limited to ~32 KB` -> `ECS container env var overrides are capped at ~8 KB` to match the accurate limit stated in handler.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)